### PR TITLE
Rename Type to FieldType

### DIFF
--- a/spanner_orm/__init__.py
+++ b/spanner_orm/__init__.py
@@ -12,16 +12,31 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Sets up shorcuts for imports from the library."""
 
 from spanner_orm import api
 from spanner_orm import condition
+from spanner_orm import field
 from spanner_orm import model
 from spanner_orm import relationship
 
 # pylint: disable=invalid-name
-Model = model.Model
-ModelRelationship = relationship.ModelRelationship
 SpannerApi = api.SpannerApi
+
+Model = model.Model
+
+ModelRelationship = relationship.ModelRelationship
+
+Boolean = field.Boolean
+Integer = field.Integer
+NullableBoolean = field.NullableBoolean
+NullableInteger = field.NullableInteger
+NullableString = field.NullableString
+NullableStringArray = field.NullableStringArray
+NullableTimestamp = field.NullableTimestamp
+String = field.String
+StringArray = field.StringArray
+Timestamp = field.Timestamp
 
 equal_to = condition.equal_to
 greater_than = condition.greater_than

--- a/spanner_orm/admin/api.py
+++ b/spanner_orm/admin/api.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Interacts with the Spanner database to read and manage table schemas."""
+"""Class that handles API calls to Spanner that deal with table metadata."""
 
 from spanner_orm import api
 
@@ -26,13 +26,18 @@ class SpannerAdminApi(api.TableReadApi):
   _connection_info = None
 
   @classmethod
-  def connect(cls, project, instance, database, create_ddl=None):
+  def connect(cls,
+              project,
+              instance,
+              database,
+              credentials=None,
+              create_ddl=None):
     """Connects to the specified database, optionally creating tables."""
-    connection_info = (project, instance, database)
+    connection_info = (project, instance, database, credentials)
     if cls._connection is not None and connection_info == cls._connection_info:
       return
 
-    client = spanner.Client(project=project)
+    client = spanner.Client(project=project, credentials=credentials)
     instance = client.instance(instance)
 
     if create_ddl is not None:

--- a/spanner_orm/admin/metadata.py
+++ b/spanner_orm/admin/metadata.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Retrieves database metadata."""
+"""Retrieves table metadata from Spanner."""
 
 from collections import defaultdict
 
@@ -26,7 +26,7 @@ from spanner_orm.schemas import index_column
 
 
 class DatabaseMetadata(object):
-  """Retrieve table metadata from Spanner and returns it in a usable format."""
+  """Gathers information about a table from Spanner."""
 
   @classmethod
   def column_update(cls, schema_change):
@@ -55,7 +55,7 @@ class DatabaseMetadata(object):
 
   @classmethod
   def models(cls, transaction=None):
-    """Constructs model classes from Spanner database schema."""
+    """Constructs model classes from Spanner table schema."""
     tables = cls._tables(transaction)
     indexes = cls._indexes(transaction)
     results = {}

--- a/spanner_orm/api.py
+++ b/spanner_orm/api.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Class that interacts with spanner database."""
+"""Class that handles API calls to Spanner."""
 
 import abc
 from google.cloud import spanner
@@ -92,15 +92,15 @@ class SpannerApi(SpannerReadApi, SpannerWriteApi):
 
   # Spanner connection methods
   @classmethod
-  def connect(cls, *, project, instance, database):
+  def connect(cls, project, instance, database, credentials=None):
     """Connects to the specified Spanner database."""
-    connection_info = (project, instance, database)
+    connection_info = (project, instance, database, credentials)
     if cls._connection is not None:
       if connection_info == cls._connection_info:
         return
       cls.hangup()
 
-    client = spanner.Client(project=project)
+    client = spanner.Client(project=project, credentials=credentials)
     instance = client.instance(instance)
     cls._connection = instance.database(database)
     cls._connection_info = connection_info

--- a/spanner_orm/field.py
+++ b/spanner_orm/field.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Helper to deal with column types in database interactions."""
+"""Helper to deal with field types in Spanner interactions."""
 
 import abc
 import datetime
@@ -20,8 +20,8 @@ import datetime
 from google.cloud.spanner_v1.proto import type_pb2
 
 
-class DatabaseType(abc.ABC):
-  """Base class for column types for database interactions."""
+class FieldType(abc.ABC):
+  """Base class for column types for Spanner interactions."""
 
   @classmethod
   def full_ddl(cls):
@@ -67,7 +67,7 @@ class NullableType(abc.ABC):
   pass
 
 
-class Boolean(DatabaseType):
+class Boolean(FieldType):
   """Represents a boolean type."""
 
   @staticmethod
@@ -91,7 +91,7 @@ class NullableBoolean(NullableType, Boolean):
   pass
 
 
-class Integer(DatabaseType):
+class Integer(FieldType):
   """Represents an integer type."""
 
   @staticmethod
@@ -115,7 +115,7 @@ class NullableInteger(NullableType, Integer):
   pass
 
 
-class String(DatabaseType):
+class String(FieldType):
   """Represents a string type."""
 
   @staticmethod
@@ -139,7 +139,7 @@ class NullableString(NullableType, String):
   pass
 
 
-class StringArray(DatabaseType):
+class StringArray(FieldType):
   """Represents an array of strings type."""
 
   @staticmethod
@@ -165,7 +165,7 @@ class NullableStringArray(NullableType, StringArray):
   pass
 
 
-class Timestamp(DatabaseType):
+class Timestamp(FieldType):
   """Represents a timestamp type."""
 
   @staticmethod

--- a/spanner_orm/model.py
+++ b/spanner_orm/model.py
@@ -232,7 +232,7 @@ class Model(abc.ABC):
 
   @classmethod
   def save_batch(cls, transaction, models):
-    """Persist all model changes in list of models to the database."""
+    """Persist all model changes in list of models to Spanner."""
     to_create, to_update = [], []
     columns = cls.columns()
     for model in models:

--- a/spanner_orm/schemas/column.py
+++ b/spanner_orm/schemas/column.py
@@ -14,11 +14,8 @@
 # limitations under the License.
 """Model for interacting with Spanner column schema table."""
 
+from spanner_orm import field
 from spanner_orm.schemas import schema
-from spanner_orm.type import ALL_TYPES
-from spanner_orm.type import Integer
-from spanner_orm.type import NullableType
-from spanner_orm.type import String
 
 
 class ColumnSchema(schema.Schema):
@@ -31,13 +28,13 @@ class ColumnSchema(schema.Schema):
   @classmethod
   def schema(cls):
     return {
-        'table_catalog': String,
-        'table_schema': String,
-        'table_name': String,
-        'column_name': String,
-        'ordinal_position': Integer,
-        'is_nullable': String,
-        'spanner_type': String
+        'table_catalog': field.String,
+        'table_schema': field.String,
+        'table_name': field.String,
+        'column_name': field.String,
+        'ordinal_position': field.Integer,
+        'is_nullable': field.String,
+        'spanner_type': field.String
     }
 
   @classmethod
@@ -48,8 +45,8 @@ class ColumnSchema(schema.Schema):
     return self.is_nullable == 'YES'
 
   def type(self):
-    for db_type in ALL_TYPES:
-      db_nullable = issubclass(db_type, NullableType)
+    for db_type in field.ALL_TYPES:
+      db_nullable = issubclass(db_type, field.NullableType)
       if self.spanner_type == db_type.ddl() and self.nullable() == db_nullable:
         return db_type
 

--- a/spanner_orm/schemas/index.py
+++ b/spanner_orm/schemas/index.py
@@ -14,10 +14,8 @@
 # limitations under the License.
 """Model for interacting with Spanner index schema table."""
 
+from spanner_orm import field
 from spanner_orm.schemas import schema
-from spanner_orm.type import Boolean
-from spanner_orm.type import NullableString
-from spanner_orm.type import String
 
 
 class IndexSchema(schema.Schema):
@@ -30,15 +28,15 @@ class IndexSchema(schema.Schema):
   @classmethod
   def schema(cls):
     return {
-        'table_catalog': String,
-        'table_schema': String,
-        'table_name': String,
-        'index_name': String,
-        'index_type': String,
-        'parent_table_name': NullableString,
-        'is_unique': Boolean,
-        'is_null_filtered': Boolean,
-        'index_state': String
+        'table_catalog': field.String,
+        'table_schema': field.String,
+        'table_name': field.String,
+        'index_name': field.String,
+        'index_type': field.String,
+        'parent_table_name': field.NullableString,
+        'is_unique': field.Boolean,
+        'is_null_filtered': field.Boolean,
+        'index_state': field.String
     }
 
   @classmethod

--- a/spanner_orm/schemas/index_column.py
+++ b/spanner_orm/schemas/index_column.py
@@ -14,10 +14,8 @@
 # limitations under the License.
 """Model for interacting with Spanner index column schema table."""
 
+from spanner_orm import field
 from spanner_orm.schemas import schema
-from spanner_orm.type import NullableInteger
-from spanner_orm.type import NullableString
-from spanner_orm.type import String
 
 
 class IndexColumnSchema(schema.Schema):
@@ -33,15 +31,15 @@ class IndexColumnSchema(schema.Schema):
   @classmethod
   def schema(cls):
     return {
-        'table_catalog': String,
-        'table_schema': String,
-        'table_name': String,
-        'index_name': String,
-        'column_name': String,
-        'ordinal_position': NullableInteger,
-        'column_ordering': NullableString,
-        'is_nullable': String,
-        'spanner_type': String
+        'table_catalog': field.String,
+        'table_schema': field.String,
+        'table_name': field.String,
+        'index_name': field.String,
+        'column_name': field.String,
+        'ordinal_position': field.NullableInteger,
+        'column_ordering': field.NullableString,
+        'is_nullable': field.String,
+        'spanner_type': field.String
     }
 
   @classmethod

--- a/spanner_orm/tests/models.py
+++ b/spanner_orm/tests/models.py
@@ -15,13 +15,13 @@
 """Models used by unit tests."""
 
 from spanner_orm import model
+from spanner_orm.field import Integer
+from spanner_orm.field import NullableInteger
+from spanner_orm.field import NullableString
+from spanner_orm.field import NullableStringArray
+from spanner_orm.field import String
+from spanner_orm.field import Timestamp
 from spanner_orm.relationship import ModelRelationship
-from spanner_orm.type import Integer
-from spanner_orm.type import NullableInteger
-from spanner_orm.type import NullableString
-from spanner_orm.type import NullableStringArray
-from spanner_orm.type import String
-from spanner_orm.type import Timestamp
 
 
 class ChildTestModel(model.Model):

--- a/spanner_orm/tests/query_test.py
+++ b/spanner_orm/tests/query_test.py
@@ -30,11 +30,11 @@ from spanner_orm.condition import not_in_list
 from spanner_orm.condition import not_less_than
 from spanner_orm.condition import order_by
 from spanner_orm.condition import OrderType
+from spanner_orm.field import Integer
+from spanner_orm.field import String
+from spanner_orm.field import Timestamp
 from spanner_orm.query import SelectQuery
 from spanner_orm.tests import models
-from spanner_orm.type import Integer
-from spanner_orm.type import String
-from spanner_orm.type import Timestamp
 
 
 def now():

--- a/spanner_orm/update.py
+++ b/spanner_orm/update.py
@@ -12,17 +12,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Used with SpannerAdminApi to manage database schema updates."""
+"""Used with SpannerAdminApi to manage Spanner schema updates."""
 
 import abc
 
 from spanner_orm import condition
+from spanner_orm import field
 from spanner_orm.schemas import index_column
-from spanner_orm.type import NullableType
 
 
 class SchemaUpdate(abc.ABC):
-  """Base class for specifying database schema update."""
+  """Base class for specifying schema updates."""
 
   @abc.abstractmethod
   def ddl(self):
@@ -66,12 +66,12 @@ class ColumnUpdate(SchemaUpdate):
     assert self._type != old_type
     assert old_type.db_type() == self._type.db_type()
 
-    if issubclass(old_type, NullableType):
+    if issubclass(old_type, field.NullableType):
       # Type was nullable, so must now be the not nullable type
-      assert not issubclass(self._type, NullableType)
+      assert not issubclass(self._type, field.NullableType)
     else:
       # Type wasn't nullable, so it must now be nullable
-      assert issubclass(self._type, NullableType)
+      assert issubclass(self._type, field.NullableType)
 
   def _validate_drop_column(self, model):
     assert self._column in model.schema()
@@ -87,7 +87,7 @@ class ColumnUpdate(SchemaUpdate):
     elif self._column in model.schema():
       self._validate_alter_column(model)
     else:
-      assert issubclass(self._type, NullableType)
+      assert issubclass(self._type, field.NullableType)
 
 
 class IndexUpdate(SchemaUpdate):


### PR DESCRIPTION
In the future, I'm going to try to add a Field class to clean up some of
these rough spots. For now, just renaming Type to FieldType and type.py
to field.py so that imports will work better. Also moved over the rest
of the imports in non-test to be of the approved style