### PR TITLE
Start populating model metadata from attributes

### DIFF
--- a/spanner_orm/__init__.py
+++ b/spanner_orm/__init__.py
@@ -28,12 +28,8 @@ Model = model.Model
 ModelRelationship = relationship.ModelRelationship
 
 Boolean = field.Boolean
+Field = field.Field
 Integer = field.Integer
-NullableBoolean = field.NullableBoolean
-NullableInteger = field.NullableInteger
-NullableString = field.NullableString
-NullableStringArray = field.NullableStringArray
-NullableTimestamp = field.NullableTimestamp
 String = field.String
 StringArray = field.StringArray
 Timestamp = field.Timestamp

--- a/spanner_orm/admin/metadata.py
+++ b/spanner_orm/admin/metadata.py
@@ -18,6 +18,7 @@ import collections
 
 from spanner_orm import condition
 from spanner_orm import error
+from spanner_orm import field
 from spanner_orm import model
 from spanner_orm import update
 from spanner_orm.admin import api
@@ -26,7 +27,7 @@ from spanner_orm.schemas import index
 from spanner_orm.schemas import index_column
 
 
-class DatabaseMetadata(object):
+class SpannerMetadata(object):
   """Gathers information about a table from Spanner."""
 
   @classmethod
@@ -97,7 +98,9 @@ class DatabaseMetadata(object):
         transaction, condition.EqualityCondition('table_catalog', ''),
         condition.EqualityCondition('table_schema', ''))
     for schema in schemas:
-      tables[schema.table_name][schema.column_name] = schema.type()
+      new_field = field.Field(schema.field_type(), nullable=schema.nullable())
+      new_field.name = schema.column_name
+      tables[schema.table_name][schema.column_name] = new_field
     return tables
 
   @classmethod

--- a/spanner_orm/condition.py
+++ b/spanner_orm/condition.py
@@ -107,11 +107,12 @@ class ColumnsEqualCondition(Condition):
 
   def _validate(self, model):
     assert self.column in model.schema()
-    origin_type = model.schema()[self.column]
+    origin = model.schema()[self.column]
     assert self.destination_column in self.destination_model.schema()
-    destination_type = self.destination_model.schema()[self.destination_column]
+    dest = self.destination_model.schema()[self.destination_column]
 
-    assert origin_type.db_type() == destination_type.db_type()
+    assert (origin.field_type() == dest.field_type() and
+            origin.nullable() == dest.nullable())
 
 
 class IncludesCondition(Condition):

--- a/spanner_orm/schemas/column.py
+++ b/spanner_orm/schemas/column.py
@@ -22,34 +22,26 @@ from spanner_orm.schemas import schema
 class ColumnSchema(schema.Schema):
   """Model for interacting with Spanner column schema table."""
 
+  __table__ = 'information_schema.columns'
+  table_catalog = field.Field(field.String)
+  table_schema = field.Field(field.String)
+  table_name = field.Field(field.String)
+  column_name = field.Field(field.String)
+  ordinal_position = field.Field(field.Integer)
+  is_nullable = field.Field(field.String)
+  spanner_type = field.Field(field.String)
+
   @staticmethod
   def primary_index_keys():
     return ['table_catalog', 'table_schema', 'table_name', 'column_name']
 
-  @classmethod
-  def schema(cls):
-    return {
-        'table_catalog': field.String,
-        'table_schema': field.String,
-        'table_name': field.String,
-        'column_name': field.String,
-        'ordinal_position': field.Integer,
-        'is_nullable': field.String,
-        'spanner_type': field.String
-    }
-
-  @classmethod
-  def table(cls):
-    return 'information_schema.columns'
-
   def nullable(self):
     return self.is_nullable == 'YES'
 
-  def type(self):
-    for db_type in field.ALL_TYPES:
-      db_nullable = issubclass(db_type, field.NullableType)
-      if self.spanner_type == db_type.ddl() and self.nullable() == db_nullable:
-        return db_type
+  def field_type(self):
+    for field_type in field.ALL_TYPES:
+      if self.spanner_type == field_type.ddl():
+        return field_type
 
     raise error.SpannerError('No corresponding Type for {}'.format(
         self.spanner_type))

--- a/spanner_orm/schemas/index.py
+++ b/spanner_orm/schemas/index.py
@@ -21,24 +21,17 @@ from spanner_orm.schemas import schema
 class IndexSchema(schema.Schema):
   """Model for interacting with Spanner index schema table."""
 
+  __table__ = 'information_schema.indexes'
+  table_catalog = field.Field(field.String)
+  table_schema = field.Field(field.String)
+  table_name = field.Field(field.String)
+  index_name = field.Field(field.String)
+  index_type = field.Field(field.String)
+  parent_table_name = field.Field(field.String, nullable=True)
+  is_unique = field.Field(field.Boolean)
+  is_null_filtered = field.Field(field.Boolean)
+  index_state = field.Field(field.String)
+
   @staticmethod
   def primary_index_keys():
     return ['table_catalog', 'table_schema', 'table_name', 'index_name']
-
-  @classmethod
-  def schema(cls):
-    return {
-        'table_catalog': field.String,
-        'table_schema': field.String,
-        'table_name': field.String,
-        'index_name': field.String,
-        'index_type': field.String,
-        'parent_table_name': field.NullableString,
-        'is_unique': field.Boolean,
-        'is_null_filtered': field.Boolean,
-        'index_state': field.String
-    }
-
-  @classmethod
-  def table(cls):
-    return 'information_schema.indexes'

--- a/spanner_orm/schemas/index_column.py
+++ b/spanner_orm/schemas/index_column.py
@@ -21,27 +21,20 @@ from spanner_orm.schemas import schema
 class IndexColumnSchema(schema.Schema):
   """Model for interacting with Spanner index column schema table."""
 
+  __table__ = 'information_schema.index_columns'
+  table_catalog = field.Field(field.String)
+  table_schema = field.Field(field.String)
+  table_name = field.Field(field.String)
+  index_name = field.Field(field.String)
+  column_name = field.Field(field.String)
+  ordinal_position = field.Field(field.Integer, nullable=True)
+  column_ordering = field.Field(field.String, nullable=True)
+  is_nullable = field.Field(field.String)
+  spanner_type = field.Field(field.String)
+
   @staticmethod
   def primary_index_keys():
     return [
         'table_catalog', 'table_schema', 'table_name', 'index_name',
         'column_name'
     ]
-
-  @classmethod
-  def schema(cls):
-    return {
-        'table_catalog': field.String,
-        'table_schema': field.String,
-        'table_name': field.String,
-        'index_name': field.String,
-        'column_name': field.String,
-        'ordinal_position': field.NullableInteger,
-        'column_ordering': field.NullableString,
-        'is_nullable': field.String,
-        'spanner_type': field.String
-    }
-
-  @classmethod
-  def table(cls):
-    return 'information_schema.index_columns'

--- a/spanner_orm/tests/admin_test.py
+++ b/spanner_orm/tests/admin_test.py
@@ -1,0 +1,91 @@
+# python3
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+from spanner_orm.admin import metadata
+from spanner_orm.schemas import column
+from spanner_orm.schemas import index
+from spanner_orm.schemas import index_column
+from spanner_orm.tests import models
+
+
+class AdminTest(unittest.TestCase):
+
+  def smalltestmodel_columns(self):
+    columns, iteration = [], 1
+    for row in models.SmallTestModel.meta.schema.values():
+      columns.append({
+          'table_catalog': '',
+          'table_schema': '',
+          'table_name': models.SmallTestModel.table(),
+          'column_name': row.name,
+          'ordinal_position': iteration,
+          'is_nullable': 'YES' if row.nullable() else 'NO',
+          'spanner_type': row.field_type().ddl()
+      })
+      iteration += 1
+    return [column.ColumnSchema(row) for row in columns]
+
+  def smalltestmodel_index_columns(self):
+    columns = []
+    for row in models.SmallTestModel.primary_index_keys():
+      columns.append({
+          'table_catalog': '',
+          'table_schema': '',
+          'table_name': models.SmallTestModel.table(),
+          'index_name': 'PRIMARY_KEY',
+          'column_name': row
+      })
+    return [index_column.IndexColumnSchema(row) for row in columns]
+
+  def smalltestmodel_indexes(self):
+    return [
+        index.IndexSchema({
+            'table_catalog': '',
+            'table_schema': '',
+            'table_name': models.SmallTestModel.table(),
+            'index_name': 'PRIMARY_KEY',
+            'index_type': 'PRIMARY_KEY',
+            'is_unique': True,
+            'index_state': 'READ_WRITE'
+        })
+    ]
+
+  @mock.patch('spanner_orm.schemas.index.IndexSchema.where')
+  @mock.patch('spanner_orm.schemas.index_column.IndexColumnSchema.where')
+  @mock.patch('spanner_orm.schemas.column.ColumnSchema.where')
+  def test_metadata(self, columns, index_columns, indexes):
+    model = models.SmallTestModel
+    columns.return_value = self.smalltestmodel_columns()
+    index_columns.return_value = self.smalltestmodel_index_columns()
+    indexes.return_value = self.smalltestmodel_indexes()
+
+    meta = metadata.SpannerMetadata.models()['SmallTestModel']
+
+    self.assertEqual(meta.table(), models.SmallTestModel.table())
+    self.assertEqual(meta.schema().keys(), model.columns())
+    for row in model.columns():
+      self.assertEqual(meta.schema()[row].field_type(),
+                       model.schema()[row].field_type())
+      self.assertEqual(meta.schema()[row].nullable(),
+                       model.schema()[row].nullable())
+    self.assertEqual(meta.primary_index_keys(),
+                     models.SmallTestModel.primary_index_keys())
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/spanner_orm/tests/model_test.py
+++ b/spanner_orm/tests/model_test.py
@@ -17,6 +17,7 @@ import datetime
 import unittest
 
 from spanner_orm import error
+from spanner_orm import field
 from spanner_orm.tests import models
 
 
@@ -112,6 +113,11 @@ class ModelTest(unittest.TestCase):
                       ' ARRAY<STRING(MAX)>) PRIMARY KEY (int_, string)')
     self.assertEqual(models.UnittestModel.create_table_ddl(), test_model_ddl)
 
+  def test_model_class_attribute(self):
+    self.assertIsInstance(models.SmallTestModel.key, field.Field)
+    self.assertEqual(models.SmallTestModel.key.field_type(), field.String)
+    self.assertFalse(models.SmallTestModel.key.nullable())
+    self.assertEqual(models.SmallTestModel.key.name, 'key')
 
 if __name__ == '__main__':
   unittest.main()

--- a/spanner_orm/tests/models.py
+++ b/spanner_orm/tests/models.py
@@ -14,38 +14,30 @@
 # limitations under the License.
 """Models used by unit tests."""
 
+from spanner_orm import field
 from spanner_orm import model
-from spanner_orm.field import Integer
-from spanner_orm.field import NullableInteger
-from spanner_orm.field import NullableString
-from spanner_orm.field import NullableStringArray
-from spanner_orm.field import String
-from spanner_orm.field import Timestamp
-from spanner_orm.relationship import ModelRelationship
+from spanner_orm import relationship
 
 
 class ChildTestModel(model.Model):
   """Model class for testing relationships"""
 
-  @staticmethod
-  def primary_index_keys():
-    return ['parent_key', 'child_key']
-
   @classmethod
   def relations(cls):
     return {
         'parent':
-            ModelRelationship(cls, 'spanner_orm.tests.models.SmallTestModel',
-                              {'parent_key': 'key'})
+            relationship.ModelRelationship(
+                cls, 'spanner_orm.tests.models.SmallTestModel',
+                {'parent_key': 'key'})
     }
 
-  @classmethod
-  def schema(cls):
-    return {'parent_key': String, 'child_key': String}
+  @staticmethod
+  def primary_index_keys():
+    return ['parent_key', 'child_key']
 
-  @classmethod
-  def table(cls):
-    return 'ChildTestModel'
+  __table__ = 'ChildTestModel'
+  parent_key = field.Field(field.String)
+  child_key = field.Field(field.String)
 
 
 class SmallTestModel(model.Model):
@@ -55,13 +47,10 @@ class SmallTestModel(model.Model):
   def primary_index_keys():
     return ['key']
 
-  @classmethod
-  def schema(cls):
-    return {'key': String, 'value_1': String, 'value_2': NullableString}
-
-  @classmethod
-  def table(cls):
-    return 'SmallTestModel'
+  __table__ = 'SmallTestModel'
+  key = field.Field(field.String)
+  value_1 = field.Field(field.String)
+  value_2 = field.Field(field.String, nullable=True)
 
 
 class UnittestModel(model.Model):
@@ -71,17 +60,10 @@ class UnittestModel(model.Model):
   def primary_index_keys():
     return ['int_', 'string']
 
-  @staticmethod
-  def schema():
-    return {
-        'int_': Integer,
-        'int_2': NullableInteger,
-        'string': String,
-        'string_2': NullableString,
-        'timestamp': Timestamp,
-        'string_array': NullableStringArray
-    }
-
-  @classmethod
-  def table(cls):
-    return 'table'
+  __table__ = 'table'
+  int_ = field.Field(field.Integer)
+  int_2 = field.Field(field.Integer, nullable=True)
+  string = field.Field(field.String)
+  string_2 = field.Field(field.String, nullable=True)
+  timestamp = field.Field(field.Timestamp)
+  string_array = field.Field(field.StringArray, nullable=True)


### PR DESCRIPTION
The popular python ORMs populate model metadata from class attributes
instead of class methods. As part of doing this, the field types are now
wrapped in a Field class, that handles the nullability checks.
Still to do: relationships, indices