### PR TITLE
Implement more of relationships and add them to model metadata

### DIFF
--- a/spanner_orm/__init__.py
+++ b/spanner_orm/__init__.py
@@ -25,11 +25,10 @@ SpannerApi = api.SpannerApi
 
 Model = model.Model
 
-ModelRelationship = relationship.ModelRelationship
-
 Boolean = field.Boolean
 Field = field.Field
 Integer = field.Integer
+Relationship = relationship.Relationship
 String = field.String
 StringArray = field.StringArray
 Timestamp = field.Timestamp

--- a/spanner_orm/condition.py
+++ b/spanner_orm/condition.py
@@ -126,20 +126,30 @@ class IncludesCondition(Condition):
     super().bind(model)
     self.relation = self.model.relations()[self.name]
 
+  @property
   def conditions(self):
     if not self.relation:
       raise error.SpannerError(
           'Condition must be bound before conditions is called')
-    return self.relation.conditions() + self._conditions
+    return self.relation.conditions + self._conditions
 
+  @property
   def destination(self):
     if not self.relation:
       raise error.SpannerError(
           'Condition must be bound before destination is called')
-    return self.relation.destination()
+    return self.relation.destination
 
+  @property
   def relation_name(self):
     return self.name
+
+  @property
+  def single(self):
+    if not self.relation:
+      raise error.SpannerError(
+          'Condition must be bound before single is called')
+    return self.relation.single
 
   def _params(self):
     return {}
@@ -156,7 +166,7 @@ class IncludesCondition(Condition):
 
   def _validate(self, model):
     assert self.name in model.relations()
-    other_model = model.relations()[self.name].destination()
+    other_model = model.relations()[self.name].destination
     for condition in self._conditions:
       condition._validate(other_model)  # pylint: disable=protected-access
 
@@ -166,14 +176,14 @@ class LimitCondition(Condition):
   LIMIT_KEY = 'limit'
   OFFSET_KEY = 'offset'
 
-  def __init__(self, limit, offset=0):
+  def __init__(self, value, offset=0):
     super().__init__()
-    for value in [limit, offset]:
-      if not isinstance(value, int):
+    for param in [value, offset]:
+      if not isinstance(param, int):
         raise error.SpannerError(
-            '{value} is not of type int'.format(value=value))
+            '{param} is not of type int'.format(param=param))
 
-    self.limit = limit
+    self.limit = value
     self.offset = offset
 
   def _params(self):

--- a/spanner_orm/tests/model_test.py
+++ b/spanner_orm/tests/model_test.py
@@ -29,7 +29,7 @@ class ModelTest(unittest.TestCase):
 
     test_model = models.UnittestModel({'int_': 0, 'string': ''})
     test_model.timestamp = timestamp
-    test_model['string_array'] = string_array
+    test_model.string_array = string_array
     self.assertEqual(
         test_model.values, {
             'int_': 0,
@@ -43,30 +43,24 @@ class ModelTest(unittest.TestCase):
     with self.assertRaises(AttributeError):
       test_model.int_ = 2
 
-    with self.assertRaises(KeyError):
-      test_model['string'] = 'foo'
-
-  def test_get_attr_item(self):
+  def test_get_attr(self):
     test_model = models.UnittestModel({'int_': 5, 'string': 'foo'})
     self.assertEqual(test_model.int_, 5)
-    self.assertEqual(test_model['int_'], 5)
     self.assertEqual(test_model.string, 'foo')
-    self.assertEqual(test_model['string'], 'foo')
     self.assertEqual(test_model.timestamp, None)
-    self.assertEqual(test_model['timestamp'], None)
 
   def test_cannot_set_invalid_type(self):
     test_model = models.UnittestModel({'int_': 0, 'string': ''})
-    with self.assertRaises(error.SpannerError):
+    with self.assertRaises(AttributeError):
       test_model.int_2 = 'foo'
 
-    with self.assertRaises(error.SpannerError):
+    with self.assertRaises(AttributeError):
       test_model.string_2 = 5
 
-    with self.assertRaises(error.SpannerError):
+    with self.assertRaises(AttributeError):
       test_model.string_array = 'foo'
 
-    with self.assertRaises(error.SpannerError):
+    with self.assertRaises(AttributeError):
       test_model.timestamp = 5
 
   def test_id(self):
@@ -118,6 +112,23 @@ class ModelTest(unittest.TestCase):
     self.assertEqual(models.SmallTestModel.key.field_type(), field.String)
     self.assertFalse(models.SmallTestModel.key.nullable())
     self.assertEqual(models.SmallTestModel.key.name, 'key')
+
+  def test_relation_get(self):
+    test_model = models.ChildTestModel({
+        'parent_key': 'parent',
+        'child_key': 'child',
+        'parent': []
+    })
+    self.assertEqual(test_model.parent, [])
+
+  def test_error_on_unretrieved_relation_get(self):
+    test_model = models.ChildTestModel({
+        'parent_key': 'parent',
+        'child_key': 'child'
+    })
+    with self.assertRaises(AttributeError):
+      _ = test_model.parent
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/spanner_orm/tests/models.py
+++ b/spanner_orm/tests/models.py
@@ -22,15 +22,6 @@ from spanner_orm import relationship
 class ChildTestModel(model.Model):
   """Model class for testing relationships"""
 
-  @classmethod
-  def relations(cls):
-    return {
-        'parent':
-            relationship.ModelRelationship(
-                cls, 'spanner_orm.tests.models.SmallTestModel',
-                {'parent_key': 'key'})
-    }
-
   @staticmethod
   def primary_index_keys():
     return ['parent_key', 'child_key']
@@ -38,6 +29,11 @@ class ChildTestModel(model.Model):
   __table__ = 'ChildTestModel'
   parent_key = field.Field(field.String)
   child_key = field.Field(field.String)
+  parent = relationship.Relationship(
+      'spanner_orm.tests.models.SmallTestModel', {'parent_key': 'key'},
+      single=True)
+  parents = relationship.Relationship('spanner_orm.tests.models.SmallTestModel',
+                                      {'parent_key': 'key'})
 
 
 class SmallTestModel(model.Model):


### PR DESCRIPTION
Finishes implementing the query result logic for includes conditions,
adds testing to the result processing, and update the metaclass logic to
also generate relationship information from class attributes.
I also stopped liking indexing into model objects, so I removed
__getitem__ and __setitem__