### PR TITLE
Populate Model.primary_keys from metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup
 
 setup(
     name='spanner-orm',
-    version='0.1.0',
+    version='0.1.1',
     description='Basic ORM for Spanner',
     maintainer='Derek Brandao',
     maintainer_email='dbrandao@google.com',

--- a/spanner_orm/condition.py
+++ b/spanner_orm/condition.py
@@ -328,7 +328,9 @@ class ListComparisonCondition(ComparisonCondition):
         operator=self.operator())
 
   def _types(self):
-    return {self.column: self.model.schema()[self.column].grpc_list_type()}
+    grpc_type = self.model.schema()[self.column].grpc_type()
+    list_type = type_pb2.Type(code=type_pb2.ARRAY, array_element_type=grpc_type)
+    return {self.column: list_type}
 
   def _validate(self, model):
     schema = model.schema()

--- a/spanner_orm/field.py
+++ b/spanner_orm/field.py
@@ -23,9 +23,10 @@ from google.cloud.spanner_v1.proto import type_pb2
 class Field(object):
   """Represents a column in a table as a field in a model."""
 
-  def __init__(self, field_type, nullable=False):
+  def __init__(self, field_type, nullable=False, primary_key=False):
     self._type = field_type
     self._nullable = nullable
+    self._primary_key = primary_key
 
   def ddl(self):
     if self._nullable:
@@ -38,11 +39,11 @@ class Field(object):
   def grpc_type(self):
     return self._type.grpc_type()
 
-  def grpc_list_type(self):
-    return self._type.grpc_list_type()
-
   def nullable(self):
     return self._nullable
+
+  def primary_key(self):
+    return self._primary_key
 
   def validate(self, value):
     if value is None:
@@ -63,11 +64,6 @@ class FieldType(abc.ABC):
   @abc.abstractmethod
   def grpc_type():
     raise NotImplementedError
-
-  @classmethod
-  def grpc_list_type(cls):
-    return type_pb2.Type(
-        code=type_pb2.ARRAY, array_element_type=cls.grpc_type())
 
   @staticmethod
   @abc.abstractmethod

--- a/spanner_orm/schemas/__init__.py
+++ b/spanner_orm/schemas/__init__.py
@@ -1,0 +1,24 @@
+# python3
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Sets up shortcuts for imports of schemas."""
+
+from spanner_orm.schemas import column
+from spanner_orm.schemas import index
+from spanner_orm.schemas import index_column
+
+# pylint: disable=invalid-name
+ColumnSchema = column.ColumnSchema
+IndexSchema = index.IndexSchema
+IndexColumnSchema = index_column.IndexColumnSchema

--- a/spanner_orm/schemas/column.py
+++ b/spanner_orm/schemas/column.py
@@ -23,17 +23,13 @@ class ColumnSchema(schema.Schema):
   """Model for interacting with Spanner column schema table."""
 
   __table__ = 'information_schema.columns'
-  table_catalog = field.Field(field.String)
-  table_schema = field.Field(field.String)
-  table_name = field.Field(field.String)
-  column_name = field.Field(field.String)
+  table_catalog = field.Field(field.String, primary_key=True)
+  table_schema = field.Field(field.String, primary_key=True)
+  table_name = field.Field(field.String, primary_key=True)
+  column_name = field.Field(field.String, primary_key=True)
   ordinal_position = field.Field(field.Integer)
   is_nullable = field.Field(field.String)
   spanner_type = field.Field(field.String)
-
-  @staticmethod
-  def primary_index_keys():
-    return ['table_catalog', 'table_schema', 'table_name', 'column_name']
 
   def nullable(self):
     return self.is_nullable == 'YES'

--- a/spanner_orm/schemas/index.py
+++ b/spanner_orm/schemas/index.py
@@ -22,16 +22,12 @@ class IndexSchema(schema.Schema):
   """Model for interacting with Spanner index schema table."""
 
   __table__ = 'information_schema.indexes'
-  table_catalog = field.Field(field.String)
-  table_schema = field.Field(field.String)
-  table_name = field.Field(field.String)
-  index_name = field.Field(field.String)
+  table_catalog = field.Field(field.String, primary_key=True)
+  table_schema = field.Field(field.String, primary_key=True)
+  table_name = field.Field(field.String, primary_key=True)
+  index_name = field.Field(field.String, primary_key=True)
   index_type = field.Field(field.String)
   parent_table_name = field.Field(field.String, nullable=True)
   is_unique = field.Field(field.Boolean)
   is_null_filtered = field.Field(field.Boolean)
   index_state = field.Field(field.String)
-
-  @staticmethod
-  def primary_index_keys():
-    return ['table_catalog', 'table_schema', 'table_name', 'index_name']

--- a/spanner_orm/schemas/index_column.py
+++ b/spanner_orm/schemas/index_column.py
@@ -22,19 +22,12 @@ class IndexColumnSchema(schema.Schema):
   """Model for interacting with Spanner index column schema table."""
 
   __table__ = 'information_schema.index_columns'
-  table_catalog = field.Field(field.String)
-  table_schema = field.Field(field.String)
-  table_name = field.Field(field.String)
-  index_name = field.Field(field.String)
-  column_name = field.Field(field.String)
+  table_catalog = field.Field(field.String, primary_key=True)
+  table_schema = field.Field(field.String, primary_key=True)
+  table_name = field.Field(field.String, primary_key=True)
+  index_name = field.Field(field.String, primary_key=True)
+  column_name = field.Field(field.String, primary_key=True)
   ordinal_position = field.Field(field.Integer, nullable=True)
   column_ordering = field.Field(field.String, nullable=True)
   is_nullable = field.Field(field.String)
   spanner_type = field.Field(field.String)
-
-  @staticmethod
-  def primary_index_keys():
-    return [
-        'table_catalog', 'table_schema', 'table_name', 'index_name',
-        'column_name'
-    ]

--- a/spanner_orm/tests/admin_test.py
+++ b/spanner_orm/tests/admin_test.py
@@ -16,10 +16,8 @@
 import unittest
 from unittest import mock
 
+from spanner_orm import schemas
 from spanner_orm.admin import metadata
-from spanner_orm.schemas import column
-from spanner_orm.schemas import index
-from spanner_orm.schemas import index_column
 from spanner_orm.tests import models
 
 
@@ -27,7 +25,7 @@ class AdminTest(unittest.TestCase):
 
   def smalltestmodel_columns(self):
     columns, iteration = [], 1
-    for row in models.SmallTestModel.meta.schema.values():
+    for row in models.SmallTestModel.schema().values():
       columns.append({
           'table_catalog': '',
           'table_schema': '',
@@ -38,11 +36,11 @@ class AdminTest(unittest.TestCase):
           'spanner_type': row.field_type().ddl()
       })
       iteration += 1
-    return [column.ColumnSchema(row) for row in columns]
+    return [schemas.ColumnSchema(row) for row in columns]
 
   def smalltestmodel_index_columns(self):
     columns = []
-    for row in models.SmallTestModel.primary_index_keys():
+    for row in models.SmallTestModel.primary_keys():
       columns.append({
           'table_catalog': '',
           'table_schema': '',
@@ -50,11 +48,11 @@ class AdminTest(unittest.TestCase):
           'index_name': 'PRIMARY_KEY',
           'column_name': row
       })
-    return [index_column.IndexColumnSchema(row) for row in columns]
+    return [schemas.IndexColumnSchema(row) for row in columns]
 
   def smalltestmodel_indexes(self):
     return [
-        index.IndexSchema({
+        schemas.IndexSchema({
             'table_catalog': '',
             'table_schema': '',
             'table_name': models.SmallTestModel.table(),
@@ -83,8 +81,8 @@ class AdminTest(unittest.TestCase):
                        model.schema()[row].field_type())
       self.assertEqual(meta.schema()[row].nullable(),
                        model.schema()[row].nullable())
-    self.assertEqual(meta.primary_index_keys(),
-                     models.SmallTestModel.primary_index_keys())
+    self.assertEqual(meta.primary_keys(),
+                     models.SmallTestModel.primary_keys())
 
 
 if __name__ == '__main__':

--- a/spanner_orm/tests/models.py
+++ b/spanner_orm/tests/models.py
@@ -22,13 +22,9 @@ from spanner_orm import relationship
 class ChildTestModel(model.Model):
   """Model class for testing relationships"""
 
-  @staticmethod
-  def primary_index_keys():
-    return ['parent_key', 'child_key']
-
   __table__ = 'ChildTestModel'
-  parent_key = field.Field(field.String)
-  child_key = field.Field(field.String)
+  parent_key = field.Field(field.String, primary_key=True)
+  child_key = field.Field(field.String, primary_key=True)
   parent = relationship.Relationship(
       'spanner_orm.tests.models.SmallTestModel', {'parent_key': 'key'},
       single=True)
@@ -39,12 +35,8 @@ class ChildTestModel(model.Model):
 class SmallTestModel(model.Model):
   """Model class used for testing"""
 
-  @staticmethod
-  def primary_index_keys():
-    return ['key']
-
   __table__ = 'SmallTestModel'
-  key = field.Field(field.String)
+  key = field.Field(field.String, primary_key=True)
   value_1 = field.Field(field.String)
   value_2 = field.Field(field.String, nullable=True)
 
@@ -52,14 +44,10 @@ class SmallTestModel(model.Model):
 class UnittestModel(model.Model):
   """Model class used for model testing"""
 
-  @staticmethod
-  def primary_index_keys():
-    return ['int_', 'string']
-
   __table__ = 'table'
-  int_ = field.Field(field.Integer)
+  int_ = field.Field(field.Integer, primary_key=True)
   int_2 = field.Field(field.Integer, nullable=True)
-  string = field.Field(field.String)
+  string = field.Field(field.String, primary_key=True)
   string_2 = field.Field(field.String, nullable=True)
   timestamp = field.Field(field.Timestamp)
   string_array = field.Field(field.StringArray, nullable=True)

--- a/spanner_orm/tests/query_test.py
+++ b/spanner_orm/tests/query_test.py
@@ -23,6 +23,8 @@ from spanner_orm import field
 from spanner_orm import query
 from spanner_orm.tests import models
 
+from google.cloud.spanner_v1.proto import type_pb2
+
 
 def now():
   return datetime.datetime.now(tz=datetime.timezone.utc)
@@ -112,9 +114,9 @@ class SqlBodyTest(unittest.TestCase):
         self.assertEqual(types, {column: type_})
 
   def test_query__where_list_comparison(self):
-    tuples = [('int_', [1, 2, 3], field.Integer.grpc_list_type()),
-              ('string', ['a', 'b', 'c'], field.String.grpc_list_type()),
-              ('timestamp', [now()], field.Timestamp.grpc_list_type())]
+    tuples = [('int_', [1, 2, 3], field.Integer.grpc_type()),
+              ('string', ['a', 'b', 'c'], field.String.grpc_type()),
+              ('timestamp', [now()], field.Timestamp.grpc_type())]
 
     conditions = [condition.in_list, condition.not_in_list]
     for column, values, type_ in tuples:
@@ -126,7 +128,8 @@ class SqlBodyTest(unittest.TestCase):
         sql, params, types = query_._where()
         self.assertEqual(sql, expected_sql)
         self.assertEqual(params, {column: values})
-        self.assertEqual(types, {column: type_})
+        list_type = type_pb2.Type(code=type_pb2.ARRAY, array_element_type=type_)
+        self.assertEqual(types, {column: list_type})
 
   def test_query__combines_properly(self):
     query_ = query.SelectQuery(models.UnittestModel, [

--- a/spanner_orm/update.py
+++ b/spanner_orm/update.py
@@ -18,7 +18,7 @@ import abc
 
 from spanner_orm import condition
 from spanner_orm import field
-from spanner_orm.schemas import index_column
+from spanner_orm import schemas
 
 
 class SchemaUpdate(abc.ABC):
@@ -76,7 +76,7 @@ class ColumnUpdate(SchemaUpdate):
   def _validate_drop_column(self, model):
     assert self._column in model.schema()
     # Verify no indices exist on the column we're trying to drop
-    num_index_columns = index_column.IndexColumnSchema.count(
+    num_index_columns = schemas.IndexColumnSchema.count(
         None, condition.EqualityCondition('column_name', self._column),
         condition.EqualityCondition('table_name', self._table))
     assert num_index_columns == 0


### PR DESCRIPTION
Added primary_key flag to Field, which is now used in the Model metadata
to fill out the primary_keys method (renamed from primary_index_keys).
Also removed grpc_list_type from Field, as it was pretty useless.