### PR TITLE
adding logging

### DIFF
--- a/spanner_orm/__init__.py
+++ b/spanner_orm/__init__.py
@@ -13,12 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Sets up shorcuts for imports from the library."""
+import logging
 
 from spanner_orm import api
 from spanner_orm import condition
 from spanner_orm import field
 from spanner_orm import model
 from spanner_orm import relationship
+
+# add NullHandler to root-module logger so that individual modules
+# won't have to.
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 # pylint: disable=invalid-name
 SpannerApi = api.SpannerApi

--- a/spanner_orm/api.py
+++ b/spanner_orm/api.py
@@ -51,7 +51,8 @@ class SpannerReadApi(abc.ABC):
   @staticmethod
   def sql_query(transaction, query, parameters, parameter_types):
     """Runs a read only SQL query."""
-    _logger.debug('%s\n%s\n%s', query, parameters, parameter_types)
+    _logger.debug('Executing SQL:\n%s\n%s\n%s',
+                  query, parameters, parameter_types)
     stream_results = transaction.execute_sql(
         query, params=parameters, param_types=parameter_types)
     return list(stream_results)

--- a/spanner_orm/api.py
+++ b/spanner_orm/api.py
@@ -15,10 +15,13 @@
 """Class that handles API calls to Spanner."""
 
 import abc
+import logging
 
 from spanner_orm import error
 
 from google.cloud import spanner
+
+_logger = logging.getLogger(__name__)
 
 
 class SpannerReadApi(abc.ABC):
@@ -39,6 +42,8 @@ class SpannerReadApi(abc.ABC):
   @staticmethod
   def find(transaction, table_name, columns, keyset):
     """Obtains rows with primary_keys from the given table."""
+    _logger.debug('Find table=%s columns=%s keys=%s',
+                  table_name, columns, keyset.keys)
     stream_results = transaction.read(
         table=table_name, columns=columns, keyset=keyset)
     return list(stream_results)
@@ -46,6 +51,7 @@ class SpannerReadApi(abc.ABC):
   @staticmethod
   def sql_query(transaction, query, parameters, parameter_types):
     """Runs a read only SQL query."""
+    _logger.debug('%s\n%s\n%s', query, parameters, parameter_types)
     stream_results = transaction.execute_sql(
         query, params=parameters, param_types=parameter_types)
     return list(stream_results)
@@ -68,16 +74,22 @@ class SpannerWriteApi(abc.ABC):
   @staticmethod
   def insert(transaction, table_name, columns, values):
     """Add rows to a table."""
+    _logger.debug('Insert table=%s columns=%s values=%s',
+                  table_name, columns, values)
     transaction.insert(table=table_name, columns=columns, values=values)
 
   @staticmethod
   def update(transaction, table_name, columns, values):
     """Updates rows of a table."""
+    _logger.debug('Update table=%s columns=%s values=%s',
+                  table_name, columns, values)
     transaction.update(table=table_name, columns=columns, values=values)
 
   @staticmethod
   def upsert(transaction, table_name, columns, values):
     """Updates existing rows of a table or adds rows if they don't exist."""
+    _logger.debug('Upsert table=%s columns=%s values=%s',
+                  table_name, columns, values)
     transaction.insert_or_update(
         table=table_name, columns=columns, values=values)
 

--- a/spanner_orm/tests/admin_test.py
+++ b/spanner_orm/tests/admin_test.py
@@ -88,5 +88,5 @@ class AdminTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-  logging.basicConfig(level=logging.DEBUG)
+  logging.basicConfig()
   unittest.main()

--- a/spanner_orm/tests/admin_test.py
+++ b/spanner_orm/tests/admin_test.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import logging
 import unittest
 from unittest import mock
 
@@ -88,4 +88,5 @@ class AdminTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+  logging.basicConfig(level=logging.DEBUG)
   unittest.main()

--- a/spanner_orm/tests/api_test.py
+++ b/spanner_orm/tests/api_test.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import unittest
 from unittest import mock
 
@@ -57,4 +58,5 @@ class ApiTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+  logging.basicConfig()
   unittest.main()

--- a/spanner_orm/tests/model_test.py
+++ b/spanner_orm/tests/model_test.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import datetime
 import unittest
 
@@ -131,4 +132,5 @@ class ModelTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+  logging.basicConfig()
   unittest.main()

--- a/spanner_orm/tests/model_test.py
+++ b/spanner_orm/tests/model_test.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import datetime
+import logging
 import unittest
 
 from spanner_orm import error

--- a/spanner_orm/tests/query_test.py
+++ b/spanner_orm/tests/query_test.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import datetime
+import logging
 import unittest
 from unittest import mock
 
@@ -252,4 +253,5 @@ class SqlBodyTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+  logging.basicConfig()
   unittest.main()


### PR DESCRIPTION
this setup seems to be best practices for a library.  there are probably other places we can add loggin, I only added to api for now.
If a client wants to see these logs, they need to:
`logging.getLogger('spanner_orm').setLevel(logging.DEBUG)`