### PR TITLE
Allow multiple conditions on the same column

### DIFF
--- a/spanner_orm/condition.py
+++ b/spanner_orm/condition.py
@@ -35,10 +35,16 @@ class Condition(abc.ABC):
 
   def __init__(self):
     self.model = None
+    self.suffix = None
 
   def bind(self, model):
     self._validate(model)
     self.model = model
+
+  def key(self, name):
+    if self.suffix:
+      return '{name}{suffix}'.format(name=name, suffix=self.suffix)
+    return name
 
   def params(self):
     if not self.model:
@@ -173,8 +179,6 @@ class IncludesCondition(Condition):
 
 class LimitCondition(Condition):
   """Used to specify a LIMIT condition in a Spanner query"""
-  LIMIT_KEY = 'limit'
-  OFFSET_KEY = 'offset'
 
   def __init__(self, value, offset=0):
     super().__init__()
@@ -186,10 +190,18 @@ class LimitCondition(Condition):
     self.limit = value
     self.offset = offset
 
+  @property
+  def _limit_key(self):
+    return self.key('limit')
+
+  @property
+  def _offset_key(self):
+    return self.key('offset')
+
   def _params(self):
-    params = {self.LIMIT_KEY: self.limit}
+    params = {self._limit_key: self.limit}
     if self.offset:
-      params[self.OFFSET_KEY] = self.offset
+      params[self._offset_key] = self.offset
     return params
 
   @staticmethod
@@ -198,14 +210,14 @@ class LimitCondition(Condition):
 
   def _sql(self):
     if self.offset:
-      return 'LIMIT @{limit} OFFSET @{offset}'.format(
-          limit=self.LIMIT_KEY, offset=self.OFFSET_KEY)
-    return 'LIMIT @{limit}'.format(limit=self.LIMIT_KEY)
+      return 'LIMIT @{limit_key} OFFSET @{offset_key}'.format(
+          limit_key=self._limit_key, offset_key=self._offset_key)
+    return 'LIMIT @{limit_key}'.format(limit_key=self._limit_key)
 
   def _types(self):
-    types = {self.LIMIT_KEY: type_pb2.Type(code=type_pb2.INT64)}
+    types = {self._limit_key: type_pb2.Type(code=type_pb2.INT64)}
     if self.offset:
-      types[self.OFFSET_KEY] = type_pb2.Type(code=type_pb2.INT64)
+      types[self._offset_key] = type_pb2.Type(code=type_pb2.INT64)
     return types
 
   def _validate(self, model):
@@ -262,26 +274,31 @@ class ComparisonCondition(Condition):
     self.column = column
     self.value = value
 
+  @property
+  def _column_key(self):
+    return self.key(self.column)
+
   @staticmethod
   @abc.abstractmethod
   def operator():
     raise NotImplementedError
 
   def _params(self):
-    return {self.column: self.value}
+    return {self._column_key: self.value}
 
   @staticmethod
   def segment():
     return Segment.WHERE
 
   def _sql(self):
-    return '{alias}.{column} {operator} @{column}'.format(
+    return '{alias}.{column} {operator} @{column_key}'.format(
         alias=self.model.column_prefix(),
         column=self.column,
-        operator=self.operator())
+        operator=self.operator(),
+        column_key=self._column_key)
 
   def _types(self):
-    return {self.column: self.model.schema()[self.column].grpc_type()}
+    return {self._column_key: self.model.schema()[self.column].grpc_type()}
 
   def _validate(self, model):
     schema = model.schema()
@@ -322,15 +339,16 @@ class ListComparisonCondition(ComparisonCondition):
   """Used to compare between a column and a list of values"""
 
   def _sql(self):
-    return '{alias}.{column} {operator} UNNEST(@{column})'.format(
+    return '{alias}.{column} {operator} UNNEST(@{column_key})'.format(
         alias=self.model.column_prefix(),
         column=self.column,
-        operator=self.operator())
+        operator=self.operator(),
+        column_key=self._column_key)
 
   def _types(self):
     grpc_type = self.model.schema()[self.column].grpc_type()
     list_type = type_pb2.Type(code=type_pb2.ARRAY, array_element_type=grpc_type)
-    return {self.column: list_type}
+    return {self._column_key: list_type}
 
   def _validate(self, model):
     schema = model.schema()

--- a/spanner_orm/query.py
+++ b/spanner_orm/query.py
@@ -26,7 +26,14 @@ class SpannerQuery(abc.ABC):
   def __init__(self, model, conditions):
     self._model = model
     self._conditions = conditions
+    self._param_offset = 0
+    self._sql = ''
+    self._parameters = {}
+    self._types = {}
     self._build()
+
+  def _param_index(self):
+    return self._param_offset + len(self._parameters)
 
   def parameters(self):
     return self._parameters
@@ -52,21 +59,20 @@ class SpannerQuery(abc.ABC):
 
   def _build(self):
     """Builds the Spanner query from the given model and conditions."""
-    segments = [
-        self._select(),
-        self._from(),
-        self._where(),
-        self._order(),
-        self._limit()
+    segment_builders = [
+        self._select,
+        self._from,
+        self._where,
+        self._order,
+        self._limit
     ]
 
     self._sql, self._parameters, self._types = '', {}, {}
-    for segment in segments:
-      segment_sql, segment_parameters, segment_types = segment
+    for segment_builder in segment_builders:
+      segment_sql, segment_parameters, segment_types = segment_builder()
       self._sql += segment_sql
-
-      self._update_unique(self._parameters, segment_parameters)
-      self._update_unique(self._types, segment_types)
+      self._parameters.update(segment_parameters)
+      self._types.update(segment_types)
 
   @abc.abstractmethod
   def _select(self):
@@ -82,9 +88,10 @@ class SpannerQuery(abc.ABC):
     sql, sql_parts, parameters, types = '', [], {}, {}
     wheres = self._segments(condition.Segment.WHERE)
     for where in wheres:
+      where.suffix = str(self._param_index() + len(parameters))
       sql_parts.append(where.sql())
-      self._update_unique(parameters, where.params())
-      self._update_unique(types, where.types())
+      parameters.update(where.params())
+      types.update(where.types())
     if sql_parts:
       sql = ' WHERE {}'.format(' AND '.join(sql_parts))
     return (sql, parameters, types)
@@ -97,6 +104,7 @@ class SpannerQuery(abc.ABC):
       if len(orders) != 1:
         raise error.SpannerError('Only one order condition may be specified')
       order = orders[0]
+      order.suffix = str(self._param_index())
       sql = ' ' + order.sql()
       parameters = order.params()
       types = order.types()
@@ -110,27 +118,24 @@ class SpannerQuery(abc.ABC):
       if len(limits) != 1:
         raise error.SpannerError('Only one limit condition may be specified')
       limit = limits[0]
+      limit.suffix = str(self._param_index())
       sql = ' ' + limit.sql()
       parameters = limit.params()
       types = limit.types()
     return (sql, parameters, types)
 
-  @staticmethod
-  def _update_unique(to_update, new_dict):
-    if not to_update.keys().isdisjoint(new_dict):
-      raise error.SpannerError(
-          'Only one condition per field is currently supported')
-
-    to_update.update(new_dict)
-
 
 class CountQuery(SpannerQuery):
   """Handles COUNT Spanner queries."""
 
+  def __init__(self, model, conditions):
+    super().__init__(model, conditions)
+    for c in conditions:
+      if c.segment() != condition.Segment.WHERE:
+        raise error.SpannerError('Only conditions that affect the WHERE clause '
+                                 'are allowed for count queries')
+
   def _select(self):
-    if self._segments(condition.Segment.JOIN):
-      raise error.SpannerError(
-          'Includes conditions are not allowed for count queries')
     return ('SELECT COUNT(*)', {}, {})
 
   def process_results(self, results):
@@ -152,12 +157,12 @@ class SelectQuery(SpannerQuery):
     ]
     joins = self._segments(condition.Segment.JOIN)
     for join in joins:
-      subquery = _SelectSubQuery(join.destination, join.conditions)
-
-      self._update_unique(parameters, subquery.parameters())
-      self._update_unique(types, subquery.types())
+      subquery = _SelectSubQuery(join.destination, join.conditions,
+                                 param_offset=self._param_index())
 
       columns.append('ARRAY({subquery})'.format(subquery=subquery.sql()))
+      parameters.update(subquery.parameters())
+      types.update(subquery.types())
     return ('{prefix} {columns}'.format(
         prefix=self._select_prefix(), columns=', '.join(columns)), parameters,
             types)
@@ -184,6 +189,10 @@ class SelectQuery(SpannerQuery):
 
 
 class _SelectSubQuery(SelectQuery):
+
+  def __init__(self, model, conditions, param_offset=0):
+    super().__init__(model, conditions)
+    self._param_offset = param_offset
 
   def _select_prefix(self):
     return 'SELECT AS STRUCT'

--- a/spanner_orm/query.py
+++ b/spanner_orm/query.py
@@ -32,7 +32,7 @@ class SpannerQuery(abc.ABC):
     self._types = {}
     self._build()
 
-  def _param_index(self):
+  def _next_param_index(self):
     return self._param_offset + len(self._parameters)
 
   def parameters(self):
@@ -88,7 +88,7 @@ class SpannerQuery(abc.ABC):
     sql, sql_parts, parameters, types = '', [], {}, {}
     wheres = self._segments(condition.Segment.WHERE)
     for where in wheres:
-      where.suffix = str(self._param_index() + len(parameters))
+      where.suffix = str(self._next_param_index() + len(parameters))
       sql_parts.append(where.sql())
       parameters.update(where.params())
       types.update(where.types())
@@ -104,7 +104,7 @@ class SpannerQuery(abc.ABC):
       if len(orders) != 1:
         raise error.SpannerError('Only one order condition may be specified')
       order = orders[0]
-      order.suffix = str(self._param_index())
+      order.suffix = str(self._next_param_index())
       sql = ' ' + order.sql()
       parameters = order.params()
       types = order.types()
@@ -118,7 +118,7 @@ class SpannerQuery(abc.ABC):
       if len(limits) != 1:
         raise error.SpannerError('Only one limit condition may be specified')
       limit = limits[0]
-      limit.suffix = str(self._param_index())
+      limit.suffix = str(self._next_param_index())
       sql = ' ' + limit.sql()
       parameters = limit.params()
       types = limit.types()
@@ -158,7 +158,7 @@ class SelectQuery(SpannerQuery):
     joins = self._segments(condition.Segment.JOIN)
     for join in joins:
       subquery = _SelectSubQuery(join.destination, join.conditions,
-                                 param_offset=self._param_index())
+                                 param_offset=self._next_param_index())
 
       columns.append('ARRAY({subquery})'.format(subquery=subquery.sql()))
       parameters.update(subquery.parameters())

--- a/spanner_orm/tests/query_test.py
+++ b/spanner_orm/tests/query_test.py
@@ -36,44 +36,48 @@ class SqlBodyTest(unittest.TestCase):
   def test_where(self, mock_db):
     models.UnittestModel.where_equal(True, int_=3)
     ((_, sql, parameters, types), _) = mock_db.sql_query.call_args
-    expected_sql = 'SELECT .* FROM table WHERE table.int_ = @int_'
+    expected_sql = 'SELECT .* FROM table WHERE table.int_ = @int_0'
     self.assertRegex(sql, expected_sql)
-    self.assertEqual({'int_': 3}, parameters)
-    self.assertEqual(types, {'int_': field.Integer.grpc_type()})
+    self.assertEqual({'int_0': 3}, parameters)
+    self.assertEqual(types, {'int_0': field.Integer.grpc_type()})
 
   @mock.patch('spanner_orm.api.SpannerApi')
   def test_count(self, mock_db):
     column, value = ('int_', 3)
     models.UnittestModel.count_equal(True, **{column: value})
     ((_, sql, parameters, types), _) = mock_db.sql_query.call_args
+
+    column_key = '{}0'.format(column)
     expected_sql = r'SELECT COUNT\(\*\) FROM table WHERE table.{} = @{}'.format(
-        column, column)
+        column, column_key)
     self.assertRegex(sql, expected_sql)
-    self.assertEqual({column: value}, parameters)
-    self.assertEqual(types, {column: field.Integer.grpc_type()})
+    self.assertEqual({column_key: value}, parameters)
+    self.assertEqual(types, {column_key: field.Integer.grpc_type()})
 
   def test_query_limit(self):
-    key, value = ('limit', 2)
+    key, value = ('limit0', 2)
     query_ = query.SelectQuery(models.UnittestModel, [condition.limit(value)])
 
-    sql, params, types = query_._limit()
-    self.assertEqual(sql, ' LIMIT @limit')
-    self.assertEqual(params, {key: value})
-    self.assertEqual(types, {key: field.Integer.grpc_type()})
+    self.assertTrue(query_.sql().endswith(' LIMIT @{}'.format(key)))
+    self.assertEqual(query_.parameters(), {key: value})
+    self.assertEqual(query_.types(), {key: field.Integer.grpc_type()})
 
     query_ = query.SelectQuery(models.UnittestModel, [])
     self.assertEqual(query_._limit(), ('', {}, {}))
 
   def test_query_limit_offset(self):
-    limit_key, limit = 'limit', 2
-    offset_key, offset = 'offset', 5
+    limit_key, limit = 'limit0', 2
+    offset_key, offset = 'offset0', 5
     query_ = query.SelectQuery(models.UnittestModel,
                                [condition.limit(limit, offset=offset)])
 
-    sql, params, types = query_._limit()
-    self.assertEqual(sql, ' LIMIT @limit OFFSET @offset')
-    self.assertEqual(params, {limit_key: limit, offset_key: offset})
-    self.assertEqual(types, {
+    self.assertTrue(query_.sql().endswith(' LIMIT @{} OFFSET @{}'.format(
+        limit_key, offset_key)))
+    self.assertEqual(query_.parameters(), {
+        limit_key: limit,
+        offset_key: offset
+    })
+    self.assertEqual(query_.types(), {
         limit_key: field.Integer.grpc_type(),
         offset_key: field.Integer.grpc_type()
     })
@@ -86,10 +90,9 @@ class SqlBodyTest(unittest.TestCase):
     query_ = query.SelectQuery(models.UnittestModel,
                                [condition.order_by(order)])
 
-    sql, params, types = query_._order()
-    self.assertEqual(sql, ' ORDER BY table.int_ DESC')
-    self.assertEqual(params, {})
-    self.assertEqual(types, {})
+    self.assertTrue(query_.sql().endswith(' ORDER BY table.int_ DESC'))
+    self.assertEqual(query_.parameters(), {})
+    self.assertEqual(query_.types(), {})
 
     query_ = query.SelectQuery(models.UnittestModel, [])
     self.assertEqual(query_._order(), ('', {}, {}))
@@ -106,12 +109,13 @@ class SqlBodyTest(unittest.TestCase):
       for condition_generator in conditions:
         current_condition = condition_generator(column, value)
         query_ = query.SelectQuery(models.UnittestModel, [current_condition])
+
+        column_key = '{}0'.format(column)
         expected_where = ' WHERE table.{} {} @{}'.format(
-            column, current_condition.operator(), column)
-        sql, params, types = query_._where()
-        self.assertEqual(sql, expected_where)
-        self.assertEqual(params, {column: value})
-        self.assertEqual(types, {column: type_})
+            column, current_condition.operator(), column_key)
+        self.assertTrue(query_.sql().endswith(expected_where))
+        self.assertEqual(query_.parameters(), {column_key: value})
+        self.assertEqual(query_.types(), {column_key: type_})
 
   def test_query__where_list_comparison(self):
     tuples = [('int_', [1, 2, 3], field.Integer.grpc_type()),
@@ -123,13 +127,14 @@ class SqlBodyTest(unittest.TestCase):
       for condition_generator in conditions:
         current_condition = condition_generator(column, values)
         query_ = query.SelectQuery(models.UnittestModel, [current_condition])
+
+        column_key = '{}0'.format(column)
         expected_sql = ' WHERE table.{} {} UNNEST(@{})'.format(
-            column, current_condition.operator(), column)
-        sql, params, types = query_._where()
-        self.assertEqual(sql, expected_sql)
-        self.assertEqual(params, {column: values})
+            column, current_condition.operator(), column_key)
         list_type = type_pb2.Type(code=type_pb2.ARRAY, array_element_type=type_)
-        self.assertEqual(types, {column: list_type})
+        self.assertTrue(query_.sql().endswith(expected_sql))
+        self.assertEqual(query_.parameters(), {column_key: values})
+        self.assertEqual(query_.types(), {column_key: list_type})
 
   def test_query__combines_properly(self):
     query_ = query.SelectQuery(models.UnittestModel, [
@@ -138,8 +143,8 @@ class SqlBodyTest(unittest.TestCase):
         condition.limit(2),
         condition.order_by(('string', condition.OrderType.DESC))
     ])
-    expected_sql = ('WHERE table.int_ = @int_ AND table.string_array != '
-                    '@string_array ORDER BY table.string DESC LIMIT @limit')
+    expected_sql = ('WHERE table.int_ = @int_0 AND table.string_array != '
+                    '@string_array1 ORDER BY table.string DESC LIMIT @limit2')
     self.assertTrue(query_.sql().endswith(expected_sql))
 
   def test_only_one_limit_allowed(self):
@@ -147,13 +152,6 @@ class SqlBodyTest(unittest.TestCase):
       query.SelectQuery(
           models.UnittestModel,
           [condition.limit(2), condition.limit(2)])
-
-  def test_only_one_condition_per_column_allowed(self):
-    with self.assertRaises(error.SpannerError):
-      query.SelectQuery(
-          models.UnittestModel,
-          [condition.equal_to('int_', 5),
-           condition.equal_to('int_', 2)])
 
   def test_includes(self):
     query_ = query.SelectQuery(models.ChildTestModel,
@@ -171,11 +169,9 @@ class SqlBodyTest(unittest.TestCase):
     query_ = query.SelectQuery(
         models.ChildTestModel,
         [condition.includes('parents', [condition.equal_to('key', 'value')])])
-    # The column order varies between test runs
     expected_sql = ('WHERE SmallTestModel.key = ChildTestModel.parent_key '
-                    'AND SmallTestModel.key = @key')
-    (sql, _, _) = query_._select()
-    self.assertRegex(sql, expected_sql)
+                    'AND SmallTestModel.key = @key0')
+    self.assertRegex(query_.sql(), expected_sql)
 
   def includes_result(self, related=1):
     child = {'parent_key': 'parent_key', 'child_key': 'child'}


### PR DESCRIPTION
Append a unique index to each parameter name being passed to spanner so
that the parameter names don't conflict. This used to happen, for
instance, when multiple conditions comparing a column against a value
pointed at the same column.