### PR TITLE
Fix admin api create_ddl codepath

### DIFF
--- a/spanner_orm/__init__.py
+++ b/spanner_orm/__init__.py
@@ -20,6 +20,7 @@ from spanner_orm import condition
 from spanner_orm import field
 from spanner_orm import model
 from spanner_orm import relationship
+from spanner_orm.admin import api as admin_api
 
 # add NullHandler to root-module logger so that individual modules
 # won't have to.
@@ -27,6 +28,7 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 # pylint: disable=invalid-name
 SpannerApi = api.SpannerApi
+SpannerAdminApi = admin_api.SpannerAdminApi
 
 Model = model.Model
 

--- a/spanner_orm/admin/api.py
+++ b/spanner_orm/admin/api.py
@@ -56,8 +56,13 @@ class SpannerAdminApi(api.SpannerReadApi):
   @classmethod
   def _connection(cls):
     if not cls._spanner_connection:
-      raise error.SpannerError('Not connected to spanner')
+      raise error.SpannerError('Not connected to Spanner')
     return cls._spanner_connection
+
+  @classmethod
+  def drop_database(cls):
+    cls._connection.drop()
+    cls.hangup()
 
   @classmethod
   def hangup(cls):

--- a/spanner_orm/admin/api.py
+++ b/spanner_orm/admin/api.py
@@ -46,7 +46,7 @@ class SpannerAdminApi(api.SpannerReadApi):
     if create_ddl is not None:
       cls._spanner_connection = instance.database(
           database, ddl_statements=create_ddl)
-      operation = cls._connection.create()
+      operation = cls._spanner_connection.create()
       operation.result()
     else:
       cls._spanner_connection = instance.database(database)

--- a/spanner_orm/tests/api_test.py
+++ b/spanner_orm/tests/api_test.py
@@ -51,6 +51,12 @@ class ApiTest(unittest.TestCase):
     with self.assertRaises(error.SpannerError):
       api.SpannerApi._connection()
 
+  @mock.patch('google.cloud.spanner.Client')
+  def test_admin_api_create_ddl_connection(self, client):
+    connection = self.mock_connection(client)
+    admin_api.SpannerAdminApi.connect('', '', '', create_ddl=['create ddl'])
+    self.assertEqual(admin_api.SpannerAdminApi._connection(), connection)
+
   def mock_connection(self, client):
     connection = mock.Mock()
     client().instance().database.return_value = connection


### PR DESCRIPTION
The unit test didn't cover this codepath. Added a unit test, fixed the
codepath, and added a shortcut to the SpannerAdminApi