### PR TITLE
Allow model inheritance

### DIFF
--- a/spanner_orm/tests/model_test.py
+++ b/spanner_orm/tests/model_test.py
@@ -130,6 +130,13 @@ class ModelTest(unittest.TestCase):
     with self.assertRaises(AttributeError):
       _ = test_model.parent
 
+  def test_inherited_fields(self):
+    self.assertEqual(models.InheritanceTestModel.key, models.SmallTestModel.key)
+
+    values = {'key': 'key', 'value_3': 'value_3'}
+    test_model = models.InheritanceTestModel(values)
+    for name, value in values.items():
+      self.assertEqual(getattr(test_model, name), value)
 
 if __name__ == '__main__':
   logging.basicConfig()

--- a/spanner_orm/tests/models.py
+++ b/spanner_orm/tests/models.py
@@ -41,6 +41,11 @@ class SmallTestModel(model.Model):
   value_2 = field.Field(field.String, nullable=True)
 
 
+class InheritanceTestModel(SmallTestModel):
+  """Model class used for testing model inheritance"""
+  value_3 = field.Field(field.String, nullable=True)
+
+
 class UnittestModel(model.Model):
   """Model class used for model testing"""
 


### PR DESCRIPTION
A project using this library had models that inherited from other
models, and the fields from the base class stopped showing up after
adding the new way of specifying schemas. This should make it work again