### PR TITLE
Fixing a couple issues found while starting to use the library

### DIFF
--- a/spanner_orm/__init__.py
+++ b/spanner_orm/__init__.py
@@ -17,6 +17,7 @@ import logging
 
 from spanner_orm import api
 from spanner_orm import condition
+from spanner_orm import error
 from spanner_orm import field
 from spanner_orm import model
 from spanner_orm import relationship
@@ -29,6 +30,7 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 # pylint: disable=invalid-name
 SpannerApi = api.SpannerApi
 SpannerAdminApi = admin_api.SpannerAdminApi
+SpannerError = error.SpannerError
 
 Model = model.Model
 
@@ -53,3 +55,5 @@ not_greater_than = condition.not_greater_than
 not_in_list = condition.not_in_list
 not_less_than = condition.not_less_than
 order_by = condition.order_by
+ORDER_ASC = condition.OrderType.ASC
+ORDER_DESC = condition.OrderType.DESC


### PR DESCRIPTION
- SpannerError was too deeply nested
- OrderType enum values were too deeply nested
- update.py hadn't yet switched from FieldTypes to Fields
- model.py had (at least) one place still using __getitem__ instead of
__getattr__
- model.py had a (at least) couple of AssertionErrors that could be
caused by client code, which means they should be SpannerErrors instead