### PR TITLE
Refactor model.py to clean it up

### DIFF
--- a/spanner_orm/admin/api.py
+++ b/spanner_orm/admin/api.py
@@ -61,7 +61,7 @@ class SpannerAdminApi(api.SpannerReadApi):
 
   @classmethod
   def drop_database(cls):
-    cls._connection.drop()
+    cls._connection().drop()
     cls.hangup()
 
   @classmethod

--- a/spanner_orm/condition.py
+++ b/spanner_orm/condition.py
@@ -95,19 +95,19 @@ class ColumnsEqualCondition(Condition):
 
   def _sql(self):
     return '{table}.{column} = {other_table}.{other_column}'.format(
-        table=self.model.table(),
+        table=self.model.table,
         column=self.column,
-        other_table=self.destination_model.table(),
+        other_table=self.destination_model.table,
         other_column=self.destination_column)
 
   def _types(self):
     return {}
 
   def _validate(self, model):
-    assert self.column in model.schema()
-    origin = model.schema()[self.column]
-    assert self.destination_column in self.destination_model.schema()
-    dest = self.destination_model.schema()[self.destination_column]
+    assert self.column in model.schema
+    origin = model.schema[self.column]
+    assert self.destination_column in self.destination_model.schema
+    dest = self.destination_model.schema[self.destination_column]
 
     assert (origin.field_type() == dest.field_type() and
             origin.nullable() == dest.nullable())
@@ -124,7 +124,7 @@ class IncludesCondition(Condition):
 
   def bind(self, model):
     super().bind(model)
-    self.relation = self.model.relations()[self.name]
+    self.relation = self.model.relations[self.name]
 
   @property
   def conditions(self):
@@ -165,8 +165,8 @@ class IncludesCondition(Condition):
     return {}
 
   def _validate(self, model):
-    assert self.name in model.relations()
-    other_model = model.relations()[self.name].destination
+    assert self.name in model.relations
+    other_model = model.relations[self.name].destination
     for condition in self._conditions:
       condition._validate(other_model)  # pylint: disable=protected-access
 
@@ -236,7 +236,7 @@ class OrderByCondition(Condition):
     orders = []
     for (column, order_type) in self.orderings:
       orders.append('{alias}.{column} {order_type}'.format(
-          alias=self.model.column_prefix(),
+          alias=self.model.column_prefix,
           column=column,
           order_type=order_type.name))
     return 'ORDER BY {orders}'.format(orders=', '.join(orders))
@@ -250,7 +250,7 @@ class OrderByCondition(Condition):
 
   def _validate(self, model):
     for (column, _) in self.orderings:
-      assert column in model.schema()
+      assert column in model.schema
 
 
 class ComparisonCondition(Condition):
@@ -276,15 +276,15 @@ class ComparisonCondition(Condition):
 
   def _sql(self):
     return '{alias}.{column} {operator} @{column}'.format(
-        alias=self.model.column_prefix(),
+        alias=self.model.column_prefix,
         column=self.column,
         operator=self.operator())
 
   def _types(self):
-    return {self.column: self.model.schema()[self.column].grpc_type()}
+    return {self.column: self.model.schema[self.column].grpc_type()}
 
   def _validate(self, model):
-    schema = model.schema()
+    schema = model.schema
     assert self.column in schema
     assert self.value is not None
     schema[self.column].validate(self.value)
@@ -323,17 +323,17 @@ class ListComparisonCondition(ComparisonCondition):
 
   def _sql(self):
     return '{alias}.{column} {operator} UNNEST(@{column})'.format(
-        alias=self.model.column_prefix(),
+        alias=self.model.column_prefix,
         column=self.column,
         operator=self.operator())
 
   def _types(self):
-    grpc_type = self.model.schema()[self.column].grpc_type()
+    grpc_type = self.model.schema[self.column].grpc_type()
     list_type = type_pb2.Type(code=type_pb2.ARRAY, array_element_type=grpc_type)
     return {self.column: list_type}
 
   def _validate(self, model):
-    schema = model.schema()
+    schema = model.schema
     assert isinstance(self.value, list)
     assert self.column in schema
     for value in self.value:
@@ -373,7 +373,7 @@ class NullableComparisonCondition(ComparisonCondition):
   def _sql(self):
     if self.is_null():
       return '{alias}.{column} {operator} NULL'.format(
-          alias=self.model.column_prefix(),
+          alias=self.model.column_prefix,
           column=self.column,
           operator=self.nullable_operator())
     return super()._sql()
@@ -384,7 +384,7 @@ class NullableComparisonCondition(ComparisonCondition):
     return super()._types()
 
   def _validate(self, model):
-    schema = model.schema()
+    schema = model.schema
     assert self.column in schema
     schema[self.column].validate(self.value)
 

--- a/spanner_orm/model.py
+++ b/spanner_orm/model.py
@@ -159,11 +159,11 @@ class ModelMeta(ModelBase):
 
   def find(cls, transaction=None, **keys):
     """Grabs the row with the given primary key."""
-    if set(kwargs.keys()) != set(cls.primary_keys):
+    if set(keys.keys()) != set(cls.primary_keys):
       raise error.SpannerError('All primary index keys must be specified')
 
     key_values = [keys[column] for column in cls.primary_keys]
-    keyset = spanner.KeySet(keys=[ordered_values])
+    keyset = spanner.KeySet(keys=[key_values])
 
     args = [cls.table, cls.columns, keyset]
     results = cls._execute_read(api.SpannerApi.find, transaction, args)

--- a/spanner_orm/query.py
+++ b/spanner_orm/query.py
@@ -75,7 +75,7 @@ class SpannerQuery(abc.ABC):
 
   def _from(self):
     """Processes the FROM segment of the SQL query."""
-    return (' FROM {}'.format(self._model.table()), {}, {})
+    return (' FROM {}'.format(self._model.table), {}, {})
 
   def _where(self):
     """Processes the WHERE segment of the SQL query."""
@@ -147,8 +147,8 @@ class SelectQuery(SpannerQuery):
     parameters, types = {}, {}
     columns = [
         '{alias}.{column}'.format(
-            alias=self._model.column_prefix(), column=column)
-        for column in self._model.columns()
+            alias=self._model.column_prefix, column=column)
+        for column in self._model.columns
     ]
     joins = self._segments(condition.Segment.JOIN)
     for join in joins:
@@ -167,9 +167,9 @@ class SelectQuery(SpannerQuery):
 
   def _process_row(self, row):
     """Parses a row of results from a Spanner query based on the conditions."""
-    values = dict(zip(self._model.columns(), row))
+    values = dict(zip(self._model.columns, row))
     joins = self._segments(condition.Segment.JOIN)
-    join_values = row[len(self._model.columns()):]
+    join_values = row[len(self._model.columns):]
     for join, join_value in zip(joins, join_values):
       subquery = _SelectSubQuery(join.destination, join.conditions)
       models = subquery.process_results(join_value)

--- a/spanner_orm/relationship.py
+++ b/spanner_orm/relationship.py
@@ -67,11 +67,11 @@ class Relationship(object):
     """Validates the dictionary of constraints and turns it into Conditions."""
     conditions = []
     for origin_column, destination_column in self._constraints.items():
-      if origin_column not in self.origin.schema():
+      if origin_column not in self.origin.schema:
         raise error.SpannerError(
             'Origin column must be present in origin model')
 
-      if destination_column not in self.destination.schema():
+      if destination_column not in self.destination.schema:
         raise error.SpannerError(
             'Destination column must be present in destination model')
       # This is backward from what you might imagine because the condition will

--- a/spanner_orm/tests/admin_test.py
+++ b/spanner_orm/tests/admin_test.py
@@ -25,11 +25,11 @@ class AdminTest(unittest.TestCase):
 
   def smalltestmodel_columns(self):
     columns, iteration = [], 1
-    for row in models.SmallTestModel.schema().values():
+    for row in models.SmallTestModel.schema.values():
       columns.append({
           'table_catalog': '',
           'table_schema': '',
-          'table_name': models.SmallTestModel.table(),
+          'table_name': models.SmallTestModel.table,
           'column_name': row.name,
           'ordinal_position': iteration,
           'is_nullable': 'YES' if row.nullable() else 'NO',
@@ -40,11 +40,11 @@ class AdminTest(unittest.TestCase):
 
   def smalltestmodel_index_columns(self):
     columns = []
-    for row in models.SmallTestModel.primary_keys():
+    for row in models.SmallTestModel.primary_keys:
       columns.append({
           'table_catalog': '',
           'table_schema': '',
-          'table_name': models.SmallTestModel.table(),
+          'table_name': models.SmallTestModel.table,
           'index_name': 'PRIMARY_KEY',
           'column_name': row
       })
@@ -55,7 +55,7 @@ class AdminTest(unittest.TestCase):
         schemas.IndexSchema({
             'table_catalog': '',
             'table_schema': '',
-            'table_name': models.SmallTestModel.table(),
+            'table_name': models.SmallTestModel.table,
             'index_name': 'PRIMARY_KEY',
             'index_type': 'PRIMARY_KEY',
             'is_unique': True,
@@ -74,15 +74,15 @@ class AdminTest(unittest.TestCase):
 
     meta = metadata.SpannerMetadata.models()['SmallTestModel']
 
-    self.assertEqual(meta.table(), models.SmallTestModel.table())
-    self.assertEqual(meta.schema().keys(), model.columns())
-    for row in model.columns():
-      self.assertEqual(meta.schema()[row].field_type(),
-                       model.schema()[row].field_type())
-      self.assertEqual(meta.schema()[row].nullable(),
-                       model.schema()[row].nullable())
-    self.assertEqual(meta.primary_keys(),
-                     models.SmallTestModel.primary_keys())
+    self.assertEqual(meta.table, models.SmallTestModel.table)
+    self.assertEqual(meta.columns, model.columns)
+    for row in model.columns:
+      self.assertEqual(meta.schema[row].field_type(),
+                       model.schema[row].field_type())
+      self.assertEqual(meta.schema[row].nullable(),
+                       model.schema[row].nullable())
+    self.assertEqual(meta.primary_keys,
+                     models.SmallTestModel.primary_keys)
 
 
 if __name__ == '__main__':

--- a/spanner_orm/tests/model_api_test.py
+++ b/spanner_orm/tests/model_api_test.py
@@ -1,0 +1,51 @@
+# python3
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+from spanner_orm import api
+from spanner_orm import error
+from spanner_orm.tests import models
+
+from google.cloud import spanner
+
+class ModelTest(unittest.TestCase):
+
+  def test_find_error_on_invalid_keys(self):
+    with self.assertRaises(error.SpannerError):
+      models.UnittestModel.find(int_=1)
+
+  @mock.patch('spanner_orm.api.SpannerApi.find')
+  def test_find_calls_api(self, find):
+    mock_transaction = mock.Mock()
+    models.UnittestModel.find(mock_transaction, string='string', int_=1)
+
+    find.assert_called_once()
+    (transaction, table, columns, keyset), _ = find.call_args
+    self.assertEqual(transaction, mock_transaction)
+    self.assertEqual(table, models.UnittestModel.table)
+    self.assertEqual(columns, models.UnittestModel.columns)
+    self.assertEqual(keyset.keys, [[1, 'string']])
+
+  @mock.patch('spanner_orm.api.SpannerApi.find')
+  def test_find_result(self, find):
+    mock_transaction = mock.Mock()
+    find.return_value = [['key', 'value_1', None]]
+    result = models.SmallTestModel.find(mock_transaction, key='key')
+
+    self.assertEqual(result.key, 'key')
+    self.assertEqual(result.value_1, 'value_1')
+    self.assertIsNone(result.value_2)

--- a/spanner_orm/tests/model_test.py
+++ b/spanner_orm/tests/model_test.py
@@ -106,7 +106,7 @@ class ModelTest(unittest.TestCase):
                       ' string STRING(MAX) NOT NULL, string_2 STRING(MAX),'
                       ' timestamp TIMESTAMP NOT NULL, string_array'
                       ' ARRAY<STRING(MAX)>) PRIMARY KEY (int_, string)')
-    self.assertEqual(models.UnittestModel.create_table_ddl(), test_model_ddl)
+    self.assertEqual(models.UnittestModel.creation_ddl, test_model_ddl)
 
   def test_model_class_attribute(self):
     self.assertIsInstance(models.SmallTestModel.key, field.Field)

--- a/spanner_orm/tests/query_test.py
+++ b/spanner_orm/tests/query_test.py
@@ -180,11 +180,11 @@ class SqlBodyTest(unittest.TestCase):
 
   def includes_result(self, related=1):
     child = {'parent_key': 'parent_key', 'child_key': 'child'}
-    result = [child[name] for name in models.ChildTestModel.columns()]
+    result = [child[name] for name in models.ChildTestModel.columns]
     parent = {'key': 'key', 'value_1': 'value_1', 'value_2': None}
     parents = []
     for _ in range(related):
-      parents.append([parent[name] for name in models.SmallTestModel.columns()])
+      parents.append([parent[name] for name in models.SmallTestModel.columns])
     result.append(parents)
     return child, parent, [result]
 

--- a/spanner_orm/update.py
+++ b/spanner_orm/update.py
@@ -47,7 +47,7 @@ class ColumnUpdate(SchemaUpdate):
   def ddl(self, model):
     if self._field is None:
       return 'ALTER TABLE {} DROP COLUMN {}'.format(self._table, self._column)
-    elif self._column in model.schema():
+    elif self._column in model.schema:
       operation = 'ALTER COLUMN'
     else:
       operation = 'ADD COLUMN'
@@ -58,14 +58,14 @@ class ColumnUpdate(SchemaUpdate):
     return self._table
 
   def _validate_alter_column(self, model):
-    assert self._column in model.schema()
-    old_field = model.schema()[self._column]
+    assert self._column in model.schema
+    old_field = model.schema[self._column]
     # Validate that the only alteration is to change column nullability
     assert self._field.field_type() == old_field.field_type()
     assert self._field.nullable() != old_field.nullable()
 
   def _validate_drop_column(self, model):
-    assert self._column in model.schema()
+    assert self._column in model.schema
     # Verify no indices exist on the column we're trying to drop
     num_index_columns = schemas.IndexColumnSchema.count(
         None, condition.EqualityCondition('column_name', self._column),
@@ -75,7 +75,7 @@ class ColumnUpdate(SchemaUpdate):
   def validate(self, model):
     if self._field is None:
       self._validate_drop_column(model)
-    elif self._column in model.schema():
+    elif self._column in model.schema:
       self._validate_alter_column(model)
     else:
       assert self._field.nullable()


### PR DESCRIPTION
Thie file basically has three different types of methods: methods that
help define a model schema and interact with it (now in the ModelBase
class), methods that use the model schema to interact with Spanner (now
in the ModelMeta class), and objects that represent rows of the table
associated with the model schema (now in the Model class)

As part of this, I got rid of a bunch of @classmethods. Now methods from
the first two categorie have to be called on a model class and methods
from the third category have to be called on a model object instance.
This means that some of the methods in the Model class have to call
methods on the metaclass, which might be a bit odd.

Also some of the methods have turned into properties. This was aided by
getting rid of the @classmethods, as a method can't be both a
@classmethod and a @property