### PR TITLE
Add force_write flag to save_batch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@
 from setuptools import setup
 setup(
     name='spanner-orm',
-    version='0.1.1',
+    version='0.1.2',
     description='Basic ORM for Spanner',
     maintainer='Derek Brandao',
     maintainer_email='dbrandao@google.com',

--- a/spanner_orm/tests/model_api_test.py
+++ b/spanner_orm/tests/model_api_test.py
@@ -22,7 +22,8 @@ from spanner_orm.tests import models
 
 from google.cloud import spanner
 
-class ModelTest(unittest.TestCase):
+
+class ModelApiTest(unittest.TestCase):
 
   def test_find_error_on_invalid_keys(self):
     with self.assertRaises(error.SpannerError):
@@ -49,3 +50,53 @@ class ModelTest(unittest.TestCase):
     self.assertEqual(result.key, 'key')
     self.assertEqual(result.value_1, 'value_1')
     self.assertIsNone(result.value_2)
+
+  @mock.patch('spanner_orm.api.SpannerApi.insert')
+  def test_create_calls_api(self, insert):
+    mock_transaction = mock.Mock()
+    models.SmallTestModel.create(mock_transaction, key='key', value_1='value')
+
+    insert.assert_called_once()
+    (transaction, table, columns, values), _ = insert.call_args
+    self.assertEqual(transaction, mock_transaction)
+    self.assertEqual(table, models.SmallTestModel.table)
+    self.assertEqual(list(columns), ['key', 'value_1'])
+    self.assertEqual(list(values), [['key', 'value']])
+
+  def test_create_error_on_invalid_keys(self):
+    with self.assertRaises(error.SpannerError):
+      models.SmallTestModel.create(key_2='key')
+
+  def assert_api_called(self, mock_api, mock_transaction):
+    mock_api.assert_called_once()
+    (transaction, table, columns, values), _ = mock_api.call_args
+    self.assertEqual(transaction, mock_transaction)
+    self.assertEqual(table, models.SmallTestModel.table)
+    self.assertEqual(list(columns), ['key', 'value_1', 'value_2'])
+    self.assertEqual(list(values), [['key', 'value', None]])
+
+  @mock.patch('spanner_orm.api.SpannerApi.insert')
+  def test_save_batch_inserts(self, insert):
+    mock_transaction = mock.Mock()
+    values = {'key': 'key', 'value_1': 'value'}
+    not_persisted = models.SmallTestModel(values)
+    models.SmallTestModel.save_batch(mock_transaction, [not_persisted])
+    self.assert_api_called(insert, mock_transaction)
+
+  @mock.patch('spanner_orm.api.SpannerApi.update')
+  def test_save_batch_updates(self, update):
+    mock_transaction = mock.Mock()
+    values = {'key': 'key', 'value_1': 'value'}
+    persisted = models.SmallTestModel(values, persisted=True)
+    models.SmallTestModel.save_batch(mock_transaction, [persisted])
+
+    self.assert_api_called(update, mock_transaction)
+
+  @mock.patch('spanner_orm.api.SpannerApi.upsert')
+  def test_save_batch_force_write_upserts(self, upsert):
+    mock_transaction = mock.Mock()
+    values = {'key': 'key', 'value_1': 'value'}
+    not_persisted = models.SmallTestModel(values)
+    models.SmallTestModel.save_batch(
+        mock_transaction, [not_persisted], force_write=True)
+    self.assert_api_called(upsert, mock_transaction)


### PR DESCRIPTION
@akefeli wanted to be able to force a write to database regardless of
whether the database has a record with the same primary key, so I've
added the force_write flag to the save_batch method to enable this.
I also started adding testing for some of the model methods, and a
couple of bugs I found in the process were fixed.