### PR TITLE
Implement deleting rows from Spanner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@
 from setuptools import setup
 setup(
     name='spanner-orm',
-    version='0.1.3',
+    version='0.1.4',
     description='Basic ORM for Spanner',
     maintainer='Derek Brandao',
     maintainer_email='dbrandao@google.com',

--- a/spanner_orm/api.py
+++ b/spanner_orm/api.py
@@ -71,6 +71,11 @@ class SpannerWriteApi(abc.ABC):
     """Wraps write and read-write queries in a transaction."""
     return cls._connection().run_in_transaction(*args, **kwargs)
 
+  @staticmethod
+  def delete(transaction, table_name, keyset):
+    _logger.debug('Delete table=%s keys=%s', table_name, keyset.keys)
+    transaction.delete(table=table_Name, keyset=keyset)
+
   # Write methods
   @staticmethod
   def insert(transaction, table_name, columns, values):

--- a/spanner_orm/model.py
+++ b/spanner_orm/model.py
@@ -220,7 +220,10 @@ class ModelMeta(ModelBase):
       return api.SpannerApi.run_write(db_api, *args)
 
   def save_batch(cls, transaction, models, force_write=False):
-    """Persist all model changes in list of models to Spanner."""
+    """Persist all model changes in list of models to Spanner.
+
+    Note that if the transaction provided is None, multiple transactions may
+    be created when calling this method."""
     work = collections.defaultdict(list)
     to_create, to_update = [], []
     for model in models:

--- a/spanner_orm/tests/model_api_test.py
+++ b/spanner_orm/tests/model_api_test.py
@@ -100,3 +100,16 @@ class ModelApiTest(unittest.TestCase):
     models.SmallTestModel.save_batch(
         mock_transaction, [not_persisted], force_write=True)
     self.assert_api_called(upsert, mock_transaction)
+
+  @mock.patch('spanner_orm.api.SpannerApi.delete')
+  def test_delete_batch_deletes(self, delete):
+    mock_transaction = mock.Mock()
+    values = {'key': 'key', 'value_1': 'value'}
+    model = models.SmallTestModel(values)
+    models.SmallTestModel.delete_batch(mock_transaction, [model])
+
+    delete.assert_called_once()
+    (transaction, table, keyset), _ = delete.call_args
+    self.assertEqual(transaction, mock_transaction)
+    self.assertEqual(table, models.SmallTestModel.table)
+    self.assertEqual(keyset.keys, [[model.key]])

--- a/spanner_orm/tests/model_test.py
+++ b/spanner_orm/tests/model_test.py
@@ -134,6 +134,7 @@ class ModelTest(parameterized.TestCase):
     values = {'key': 'key', 'value_1': 'value_1'}
     model = models.SmallTestModel(values, persisted=False)
 
+    find.return_value = None
     self.assertIsNone(model.reload())
     find.assert_called_once()
     (transaction,), kwargs = find.call_args
@@ -172,8 +173,18 @@ class ModelTest(parameterized.TestCase):
     model.save()
     update.assert_not_called()
 
-  def test_reload(self):
-    pass
+  @mock.patch('spanner_orm.api.SpannerApi.delete')
+  def test_delete_deletes(self, delete):
+    mock_transaction = mock.Mock()
+    values = {'key': 'key', 'value_1': 'value_1'}
+    model = models.SmallTestModel(values)
+    model.delete(mock_transaction)
+
+    delete.assert_called_once()
+    (transaction, table, keyset), _ = delete.call_args
+    self.assertEqual(transaction, mock_transaction)
+    self.assertEqual(table, models.SmallTestModel.table)
+    self.assertEqual(keyset.keys, [[model.key]])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added delete_batch on ModelMeta to delete batches of rows and delete on Model to delete a single row.