### PR TITLE
Fix typo in api.py

### DIFF
--- a/spanner_orm/api.py
+++ b/spanner_orm/api.py
@@ -74,7 +74,7 @@ class SpannerWriteApi(abc.ABC):
   @staticmethod
   def delete(transaction, table_name, keyset):
     _logger.debug('Delete table=%s keys=%s', table_name, keyset.keys)
-    transaction.delete(table=table_Name, keyset=keyset)
+    transaction.delete(table=table_name, keyset=keyset)
 
   # Write methods
   @staticmethod


### PR DESCRIPTION
This doesn't add any tests because this is the code that is at the integration point between spanner-orm and the spanner client library. In order to add any reasonable testing, we'd actually need to talk to a spanner instance, but I'm not going to make a publicly accessible spanner instance so that we can have that sort of testing in this repo