### PR TITLE
Allow pool to be specified when connecting to Spanner

### DIFF
--- a/spanner_orm/api.py
+++ b/spanner_orm/api.py
@@ -114,7 +114,7 @@ class SpannerApi(SpannerReadApi, SpannerWriteApi):
 
   # Spanner connection methods
   @classmethod
-  def connect(cls, project, instance, database, credentials=None):
+  def connect(cls, project, instance, database, credentials=None, pool=None):
     """Connects to the specified Spanner database."""
     connection_info = (project, instance, database, credentials)
     if cls._spanner_connection is not None:
@@ -124,7 +124,7 @@ class SpannerApi(SpannerReadApi, SpannerWriteApi):
 
     client = spanner.Client(project=project, credentials=credentials)
     instance = client.instance(instance)
-    cls._spanner_connection = instance.database(database)
+    cls._spanner_connection = instance.database(database, pool=pool)
     cls._connection_info = connection_info
 
   @classmethod


### PR DESCRIPTION
I think the default BurstyPool with target size 10 isn't going to be
sufficient for our use cases. This will allow specifying a different
session pool when using spanner_orm