### PR TITLE
Skip validation on values from Spanner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@
 from setuptools import setup
 setup(
     name='spanner-orm',
-    version='0.1.5',
+    version='0.1.6',
     description='Basic ORM for Spanner',
     maintainer='Derek Brandao',
     maintainer_email='dbrandao@google.com',

--- a/spanner_orm/field.py
+++ b/spanner_orm/field.py
@@ -47,7 +47,7 @@ class Field(object):
 
   def validate(self, value):
     if value is None:
-      assert self._nullable
+      assert self._nullable, 'None set for non-nullable field'
     else:
       self._type.validate_type(value)
 

--- a/spanner_orm/tests/admin_test.py
+++ b/spanner_orm/tests/admin_test.py
@@ -46,7 +46,9 @@ class AdminTest(unittest.TestCase):
           'table_schema': '',
           'table_name': models.SmallTestModel.table,
           'index_name': 'PRIMARY_KEY',
-          'column_name': row
+          'column_name': row,
+          'is_nullable': 'FALSE',
+          'spanner_type': 'STRING'
       })
     return [schemas.IndexColumnSchema(row) for row in columns]
 
@@ -59,6 +61,7 @@ class AdminTest(unittest.TestCase):
             'index_name': 'PRIMARY_KEY',
             'index_type': 'PRIMARY_KEY',
             'is_unique': True,
+            'is_null_filtered': False,
             'index_state': 'READ_WRITE'
         })
     ]

--- a/spanner_orm/tests/api_test.py
+++ b/spanner_orm/tests/api_test.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import logging
 import unittest
 from unittest import mock

--- a/spanner_orm/tests/decorator_test.py
+++ b/spanner_orm/tests/decorator_test.py
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
+import unittest
 from unittest import mock
 
 from absl.testing import parameterized
@@ -67,3 +69,8 @@ def mock_spanner_method(mock_transaction):
     return method(mock_transaction, *args, **kwargs)
 
   return _mock_spanner_method
+
+
+if __name__ == '__main__':
+  logging.basicConfig()
+  unittest.main()

--- a/spanner_orm/tests/model_api_test.py
+++ b/spanner_orm/tests/model_api_test.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import logging
 import unittest
 from unittest import mock
 
@@ -113,3 +113,8 @@ class ModelApiTest(unittest.TestCase):
     self.assertEqual(transaction, mock_transaction)
     self.assertEqual(table, models.SmallTestModel.table)
     self.assertEqual(keyset.keys, [[model.key]])
+
+
+if __name__ == '__main__':
+  logging.basicConfig()
+  unittest.main()

--- a/spanner_orm/tests/query_test.py
+++ b/spanner_orm/tests/query_test.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import datetime
 import logging
 import unittest


### PR DESCRIPTION
If the `persisted` flag is True during model instance creation, we
should assume that the values came from Spanner, and thus we don't have
to validate them. Otherwise, we should validate all field values.

Originally we hadn't been running validation on all field values, so we
were allowing some fields to be None when they were not set as nullable.
I've updated the tests so that they pass again after this change.