### PR TITLE
Skip calling __setattr__ during model __init__

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@
 from setuptools import setup
 setup(
     name='spanner-orm',
-    version='0.1.6',
+    version='0.1.7',
     description='Basic ORM for Spanner',
     maintainer='Derek Brandao',
     maintainer_email='dbrandao@google.com',

--- a/spanner_orm/model.py
+++ b/spanner_orm/model.py
@@ -271,8 +271,9 @@ class Model(object, metaclass=ModelMeta):
   """Maps to a table in spanner and has basic functions for querying tables."""
 
   def __init__(self, values, persisted=False):
-    self.start_values = {}
-    self._persisted = persisted
+    start_values = {}
+    self.__dict__['start_values'] = start_values
+    self.__dict__['_persisted'] = persisted
 
     # If the values came from Spanner, trust them and skip validation
     if not persisted:
@@ -288,17 +289,19 @@ class Model(object, metaclass=ModelMeta):
 
     for column in self._columns:
       value = values.get(column)
-      self.start_values[column] = copy.copy(value)
-      super().__setattr__(column, value)
+      start_values[column] = copy.copy(value)
+      self.__dict__[column] = value
 
     for relation in self._relations:
       if relation in values:
-        super().__setattr__(relation, values[relation])
+        self.__dict__[relation] = values[relation]
 
   def __setattr__(self, name, value):
-    if name in self._primary_keys or name in self._relations:
+    if name in self._relations:
       raise AttributeError(name)
-    if name in self._fields:
+    elif name in self._fields:
+      if name in self._primary_keys:
+        raise AttributeError(name)
       self._metaclass.validate_value(name, value, AttributeError)
     super().__setattr__(name, value)
 


### PR DESCRIPTION
I'm a little less certain about this change: it makes model
initialization significantly faster, but it does so by directly using
__dict__ (so we skip hitting our overridden __setattr__ method). This
makes it incompatible with using __slots__ later on. On the other hand,
I wasn't super happy with calling super().__setattr__() previously.
I also updated __setattr__ to make it a bit faster when setting
non-model attributes (`in` on a list is somewhat slow, so we avoid
checking primary keys until we have to)