### PR TITLE
Add find_multi

### DIFF
--- a/spanner_orm/model.py
+++ b/spanner_orm/model.py
@@ -158,17 +158,24 @@ class ModelMeta(ModelBase):
 
   def find(cls, transaction=None, **keys):
     """Grabs the row with the given primary key."""
-    if set(keys.keys()) != set(cls.primary_keys):
-      raise error.SpannerError('All primary index keys must be specified')
-
     key_values = [keys[column] for column in cls.primary_keys]
     keyset = spanner.KeySet(keys=[key_values])
 
     args = [cls.table, cls.columns, keyset]
     results = cls._execute_read(api.SpannerApi.find, transaction, args)
     resources = cls._results_to_models(results)
-
     return resources[0] if resources else None
+
+  def find_multi(cls, transaction, keys):
+    key_values = []
+    for key in keys:
+      key_values.append([key[column] for column in cls.primary_keys])
+    keyset = spanner.KeySet(keys=key_values)
+
+    args = [cls.table, cls.columns, keyset]
+    results = cls._execute_read(api.SpannerApi.find, transaction, args)
+    resources = cls._results_to_models(results)
+    return resources
 
   def where(cls, transaction, *conditions):
     """Implementation of the SELECT query."""

--- a/spanner_orm/model.py
+++ b/spanner_orm/model.py
@@ -158,12 +158,7 @@ class ModelMeta(ModelBase):
 
   def find(cls, transaction=None, **keys):
     """Grabs the row with the given primary key."""
-    key_values = [keys[column] for column in cls.primary_keys]
-    keyset = spanner.KeySet(keys=[key_values])
-
-    args = [cls.table, cls.columns, keyset]
-    results = cls._execute_read(api.SpannerApi.find, transaction, args)
-    resources = cls._results_to_models(results)
+    resources = cls.find_multi(transaction, [keys])
     return resources[0] if resources else None
 
   def find_multi(cls, transaction, keys):


### PR DESCRIPTION
Adding a method that will make it easier to find multiple rows from
Spanner at the same time, because using the find API is faster than
using execute_sql with a WHERE IN UNNEST(). I debated changing the
find method so that it allows finding multiple rows, but couldn't
decide one way or the other. Thoughts?