### PR TITLE
Fix reload bug

### DIFF
--- a/spanner_orm/model.py
+++ b/spanner_orm/model.py
@@ -362,7 +362,8 @@ class Model(object, metaclass=ModelMeta):
     if updated_object is None:
       return None
     for column in self._columns:
-      setattr(self, column, getattr(updated_object, column))
+      if column not in self._primary_keys:
+        setattr(self, column, getattr(updated_object, column))
     self._persisted = True
     return self
 

--- a/spanner_orm/tests/model_test.py
+++ b/spanner_orm/tests/model_test.py
@@ -142,6 +142,16 @@ class ModelTest(parameterized.TestCase):
     self.assertIsNone(transaction)
     self.assertEqual(kwargs, model.id())
 
+  @mock.patch('spanner_orm.model.ModelMeta.find')
+  def test_reload_reloads(self, find):
+    values = {'key': 'key', 'value_1': 'value_1'}
+    model = models.SmallTestModel(values, persisted=False)
+
+    updated_values = {'key': 'key', 'value_1': 'value_2'}
+    find.return_value = models.SmallTestModel(updated_values)
+    model.reload()
+    self.assertEqual(model.value_1, updated_values['value_1'])
+
   @mock.patch('spanner_orm.model.ModelMeta.create')
   def test_save_creates(self, create):
     values = {'key': 'key', 'value_1': 'value_1'}


### PR DESCRIPTION
After a reload, we try to update all fields, but we're not allowed to
update primary key fields. The test for reload didn't actually exercise
the reload functionality, so I've added a new test that does.