### PR TITLE
Allow child models to be interleaved in parent model tables

### DIFF
--- a/spanner_orm/query.py
+++ b/spanner_orm/query.py
@@ -177,7 +177,8 @@ class SelectQuery(SpannerQuery):
     """Parses a row of results from a Spanner query based on the conditions."""
     values = dict(zip(self._model.columns, row))
     join_values = row[len(self._model.columns):]
-    for join, subquery, join_value in zip(self._joins, self._subqueries, join_values):
+    for join, subquery, join_value in zip(self._joins, self._subqueries,
+                                          join_values):
       models = subquery.process_results(join_value)
       if join.single:
         if len(models) > 1:

--- a/spanner_orm/tests/model_api_test.py
+++ b/spanner_orm/tests/model_api_test.py
@@ -16,11 +16,8 @@ import logging
 import unittest
 from unittest import mock
 
-from spanner_orm import api
 from spanner_orm import error
 from spanner_orm.tests import models
-
-from google.cloud import spanner
 
 
 class ModelApiTest(unittest.TestCase):

--- a/spanner_orm/tests/model_test.py
+++ b/spanner_orm/tests/model_test.py
@@ -18,7 +18,6 @@ import unittest
 from unittest import mock
 
 from absl.testing import parameterized
-from spanner_orm import error
 from spanner_orm import field
 from spanner_orm.tests import models
 
@@ -99,6 +98,14 @@ class ModelTest(parameterized.TestCase):
                       ' timestamp TIMESTAMP NOT NULL, string_array'
                       ' ARRAY<STRING(MAX)>) PRIMARY KEY (int_, string)')
     self.assertEqual(models.UnittestModel.creation_ddl, test_model_ddl)
+
+  def test_interleaved_creation_ddl(self):
+    test_model_ddl = ('CREATE TABLE ChildTestModel ('
+                      'parent_key STRING(MAX) NOT NULL, '
+                      'child_key STRING(MAX) NOT NULL) '
+                      'PRIMARY KEY (parent_key, child_key), '
+                      'INTERLEAVE IN PARENT SmallTestModel ON CASCADE DELETE')
+    self.assertEqual(models.ChildTestModel.creation_ddl, test_model_ddl)
 
   def test_field_exists_on_model_class(self):
     self.assertIsInstance(models.SmallTestModel.key, field.Field)

--- a/spanner_orm/tests/models.py
+++ b/spanner_orm/tests/models.py
@@ -19,19 +19,6 @@ from spanner_orm import model
 from spanner_orm import relationship
 
 
-class ChildTestModel(model.Model):
-  """Model class for testing relationships"""
-
-  __table__ = 'ChildTestModel'
-  parent_key = field.Field(field.String, primary_key=True)
-  child_key = field.Field(field.String, primary_key=True)
-  parent = relationship.Relationship(
-      'spanner_orm.tests.models.SmallTestModel', {'parent_key': 'key'},
-      single=True)
-  parents = relationship.Relationship('spanner_orm.tests.models.SmallTestModel',
-                                      {'parent_key': 'key'})
-
-
 class SmallTestModel(model.Model):
   """Model class used for testing"""
 
@@ -39,6 +26,20 @@ class SmallTestModel(model.Model):
   key = field.Field(field.String, primary_key=True)
   value_1 = field.Field(field.String)
   value_2 = field.Field(field.String, nullable=True)
+
+
+class ChildTestModel(model.Model):
+  """Model class for testing relationships"""
+
+  __table__ = 'ChildTestModel'
+  __interleaved__ = SmallTestModel
+  parent_key = field.Field(field.String, primary_key=True)
+  child_key = field.Field(field.String, primary_key=True)
+  parent = relationship.Relationship(
+      'spanner_orm.tests.models.SmallTestModel', {'parent_key': 'key'},
+      single=True)
+  parents = relationship.Relationship('spanner_orm.tests.models.SmallTestModel',
+                                      {'parent_key': 'key'})
 
 
 class InheritanceTestModel(SmallTestModel):

--- a/spanner_orm/tests/query_test.py
+++ b/spanner_orm/tests/query_test.py
@@ -209,7 +209,7 @@ class QueryTest(parameterized.TestCase):
     child_values, parent_values, rows = self.includes_result(related=2)
     result = select_query.process_results(rows)[0]
 
-    self.assertEqual(len(result.parents), 2)
+    self.assertLen(result.parents, 2)
     for name, value in child_values.items():
       self.assertEqual(getattr(result, name), value)
 
@@ -240,7 +240,10 @@ class QueryTest(parameterized.TestCase):
     expected_sql = '((table.int_ = @int_0) OR (table.int_ = @int_1))'
     self.assertEndsWith(select_query.sql(), expected_sql)
     self.assertEqual(select_query.parameters(), {'int_0': 1, 'int_1': 2})
-    self.assertEqual(select_query.types(), {'int_0': field.Integer.grpc_type(), 'int_1': field.Integer.grpc_type()})
+    self.assertEqual(select_query.types(), {
+        'int_0': field.Integer.grpc_type(),
+        'int_1': field.Integer.grpc_type()
+    })
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add __interleaved__ attribute that specifies that a model should be
interleaved in the parent model's table. There is currently no
validation done that verifies the child model is allowed to be
interleaved in the parent model's table, I plan on doing that when I
start working more on migrations