### PR TITLE
Add reading and writing of migration files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ setup(
     maintainer_email='dbrandao@google.com',
     url='https://github.com/google/python-spanner-orm',
     packages=['spanner_orm', 'spanner_orm.admin'],
-    install_requires=[
-        'google-cloud-spanner >= 1.6, <2.0.0dev'
-    ],
+    install_requires=['google-cloud-spanner >= 1.6, <2.0.0dev'],
     tests_require=['absl-py'],
-    entry_points={'console_scripts': ['spanner-orm = spanner_orm.admin.scripts:main']})
+    entry_points={
+        'console_scripts': ['spanner-orm = spanner_orm.admin.scripts:main']
+    })

--- a/spanner_orm/admin/migration.skel
+++ b/spanner_orm/admin/migration.skel
@@ -1,0 +1,18 @@
+"""$migration_name
+
+Migration ID: $migration_id
+Created: $current_date
+"""
+
+migration_id = '$migration_id'
+prev_migration = $prev_migration_id
+
+from spanner_orm.admin import update
+
+# Returns a SchemaUpdate object that tells what should be changed
+def upgrade():
+  pass
+
+# Returns a SchemaUpdate object that tells how to roll back the changes
+def downgrade():
+  pass

--- a/spanner_orm/admin/migration.skel
+++ b/spanner_orm/admin/migration.skel
@@ -4,8 +4,8 @@ Migration ID: $migration_id
 Created: $current_date
 """
 
-migration_id = '$migration_id'
-prev_migration = $prev_migration_id
+migration_id = $migration_id
+prev_migration_id = $prev_migration_id
 
 from spanner_orm.admin import update
 

--- a/spanner_orm/admin/migration_manager.py
+++ b/spanner_orm/admin/migration_manager.py
@@ -1,0 +1,122 @@
+# python3
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Handles reading and writing of migration files."""
+import datetime
+import importlib
+import os
+import re
+import string
+import uuid
+
+from spanner_orm import error
+
+
+class MigrationManager(object):
+  """Handles reading and writing of migration files."""
+  DEFAULT_DIRECTORY = 'migrations'
+
+  def __init__(self, basedir=None):
+    self.basedir = basedir or self.DEFAULT_DIRECTORY
+    self._migrations = None
+
+    if not os.path.exists(self.basedir):
+      os.makedirs(self.basedir)
+
+  def generate(self, migration_name):
+    """Creates a new migration that is the last migration to be executed."""
+    migration_id = uuid.uuid4().hex[-12:]
+    prev_id = self.migrations[-1].migration_id if self.migrations else None
+    prev = "'{}'".format(prev_id) if prev_id else 'None'
+    now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M')
+
+    skeleton_directory = os.path.dirname(os.path.abspath(__file__))
+    skeleton_file = os.path.join(skeleton_directory, 'migration.skel')
+    with open(skeleton_file, 'r') as skeleton:
+      migration_skeleton = string.Template(skeleton.read())
+    migration_content = migration_skeleton.substitute(
+        migration_name=migration_name,
+        migration_id=migration_id,
+        prev_migration_id=prev,
+        current_date=now)
+
+    filename = '{name}_{migration_id}.py'.format(
+        name=re.sub(r'\W', '_', migration_name), migration_id=migration_id)
+    filepath = os.path.join(self.basedir, filename)
+    with open(filepath, 'w') as f:
+      f.write(migration_content)
+    return filepath
+
+  @property
+  def migrations(self):
+    """Loads and orders all migrations in the base dir."""
+    if self._migrations is None:
+      unordered_migrations = self._all_migrations()
+      self._migrations = self._order_migrations(unordered_migrations)
+    return self._migrations
+
+  def _migration_from_file(self, filename):
+    """Loads a single migration from the given filename in the base dir."""
+    module_name = re.sub(r'\W', '_', filename)
+    path = os.path.join(self.basedir, filename)
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    if not hasattr(module, 'migration_id'):
+      raise error.SpannerError('{} has no migration id'.format(path))
+    return module
+
+  def _all_migrations(self):
+    """Loads all migrations from the base dir."""
+    migrations = []
+    for filename in os.listdir(self.basedir):
+      _, ext = os.path.splitext(filename)
+      if ext == '.py':
+        migrations.append(self._migration_from_file(filename))
+    return migrations
+
+  def _order_migrations(self, migrations):
+    """Returns list of migrations in the order they have to be applied."""
+    if not migrations:
+      return []
+
+    id_map = {migration.migration_id: migration for migration in migrations}
+    start_migration = None
+    for migration_id, migration in id_map.items():
+      if migration.prev_migration and migration.prev_migration in id_map:
+        current = id_map[migration.prev_migration]
+        if hasattr(current, 'next'):
+          raise error.SpannerError(
+              '{name} has unclear successor migration'.format(
+                  name=current.migration_id))
+        current.next = migration_id
+      else:
+        if start_migration:
+          raise error.SpannerError(
+              'Multiple migrations have no valid previous migration')
+        start_migration = migration_id
+
+    if not start_migration:
+      raise error.SpannerError('No valid migration to start from')
+
+    migration_order = []
+    while start_migration:
+      current = id_map[start_migration]
+      migration_order.append(current)
+      start_migration = getattr(current, 'next', None)
+
+    if len(migration_order) != len(id_map):
+      raise error.SpannerError('{} has no successor migration'.format(
+          migration_order[-1].migration_id))
+    return migration_order

--- a/spanner_orm/admin/migration_manager.py
+++ b/spanner_orm/admin/migration_manager.py
@@ -38,7 +38,6 @@ class MigrationManager(object):
     """Creates a new migration that is the last migration to be executed."""
     migration_id = uuid.uuid4().hex[-12:]
     prev_id = self.migrations[-1].migration_id if self.migrations else None
-    prev = "'{}'".format(prev_id) if prev_id else 'None'
     now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M')
 
     skeleton_directory = os.path.dirname(os.path.abspath(__file__))
@@ -47,8 +46,8 @@ class MigrationManager(object):
       migration_skeleton = string.Template(skeleton.read())
     migration_content = migration_skeleton.substitute(
         migration_name=migration_name,
-        migration_id=migration_id,
-        prev_migration_id=prev,
+        migration_id=repr(migration_id),
+        prev_migration_id=repr(prev_id),
         current_date=now)
 
     filename = '{name}_{migration_id}.py'.format(
@@ -94,8 +93,8 @@ class MigrationManager(object):
     id_map = {migration.migration_id: migration for migration in migrations}
     start_migration = None
     for migration_id, migration in id_map.items():
-      if migration.prev_migration and migration.prev_migration in id_map:
-        current = id_map[migration.prev_migration]
+      if migration.prev_migration_id and migration.prev_migration_id in id_map:
+        current = id_map[migration.prev_migration_id]
         if hasattr(current, 'next'):
           raise error.SpannerError(
               '{name} has unclear successor migration'.format(

--- a/spanner_orm/admin/scripts.py
+++ b/spanner_orm/admin/scripts.py
@@ -1,0 +1,45 @@
+#python3
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Entry point for spanner_orm scripts."""
+import argparse
+from spanner_orm.admin import migration_manager
+
+
+def generate(args):
+  manager = migration_manager.MigrationManager(args.directory)
+  manager.generate(args.name)
+
+
+def main(as_module=False):
+  prog = 'spanner-orm' if as_module else None
+  parser = argparse.ArgumentParser(prog=prog)
+  subparsers = parser.add_subparsers(
+      title='subcommands', description='valid subcommands')
+
+  generate_parser = subparsers.add_parser(
+      'generate', help='Generate a new migration')
+  generate_parser.add_argument('name', help='Short name of the migration')
+  generate_parser.add_argument('--directory')
+  generate_parser.set_defaults(execute=generate)
+
+  args = parser.parse_args()
+  if hasattr(args, 'execute'):
+    args.execute(args)
+  else:
+    parser.print_help()
+
+
+if __name__ == '__main__':
+  main(as_module=True)

--- a/spanner_orm/admin/scripts.py
+++ b/spanner_orm/admin/scripts.py
@@ -1,4 +1,4 @@
-#python3
+# python3
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spanner_orm/tests/migrations/test_1_4a7a7dee0718.py
+++ b/spanner_orm/tests/migrations/test_1_4a7a7dee0718.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""test_1
+"""test_1.
 
 Migration ID: 4a7a7dee0718
 Created: 2019-02-27 18:52
@@ -21,11 +21,11 @@ Created: 2019-02-27 18:52
 migration_id = '4a7a7dee0718'
 prev_migration = None
 
-from spanner_orm.admin import update
 
 # Returns a SchemaUpdate object that tells what should be changed
 def upgrade():
   pass
+
 
 # Returns a SchemaUpdate object that tells how to roll back the changes
 def downgrade():

--- a/spanner_orm/tests/migrations/test_1_4a7a7dee0718.py
+++ b/spanner_orm/tests/migrations/test_1_4a7a7dee0718.py
@@ -19,7 +19,7 @@ Created: 2019-02-27 18:52
 """
 
 migration_id = '4a7a7dee0718'
-prev_migration = None
+prev_migration_id = None
 
 
 # Returns a SchemaUpdate object that tells what should be changed

--- a/spanner_orm/tests/migrations/test_1_4a7a7dee0718.py
+++ b/spanner_orm/tests/migrations/test_1_4a7a7dee0718.py
@@ -12,18 +12,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""spanner_orm setup file."""
-from setuptools import setup
-setup(
-    name='spanner-orm',
-    version='0.1.8',
-    description='Basic ORM for Spanner',
-    maintainer='Derek Brandao',
-    maintainer_email='dbrandao@google.com',
-    url='https://github.com/google/python-spanner-orm',
-    packages=['spanner_orm', 'spanner_orm.admin'],
-    install_requires=[
-        'google-cloud-spanner >= 1.6, <2.0.0dev'
-    ],
-    tests_require=['absl-py'],
-    entry_points={'console_scripts': ['spanner-orm = spanner_orm.admin.scripts:main']})
+"""test_1
+
+Migration ID: 4a7a7dee0718
+Created: 2019-02-27 18:52
+"""
+
+migration_id = '4a7a7dee0718'
+prev_migration = None
+
+from spanner_orm.admin import update
+
+# Returns a SchemaUpdate object that tells what should be changed
+def upgrade():
+  pass
+
+# Returns a SchemaUpdate object that tells how to roll back the changes
+def downgrade():
+  pass

--- a/spanner_orm/tests/migrations/test_2_5c078bbb4d43.py
+++ b/spanner_orm/tests/migrations/test_2_5c078bbb4d43.py
@@ -12,18 +12,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""spanner_orm setup file."""
-from setuptools import setup
-setup(
-    name='spanner-orm',
-    version='0.1.8',
-    description='Basic ORM for Spanner',
-    maintainer='Derek Brandao',
-    maintainer_email='dbrandao@google.com',
-    url='https://github.com/google/python-spanner-orm',
-    packages=['spanner_orm', 'spanner_orm.admin'],
-    install_requires=[
-        'google-cloud-spanner >= 1.6, <2.0.0dev'
-    ],
-    tests_require=['absl-py'],
-    entry_points={'console_scripts': ['spanner-orm = spanner_orm.admin.scripts:main']})
+"""test_2
+
+Migration ID: 5c078bbb4d43
+Created: 2019-02-27 18:52
+"""
+
+migration_id = '5c078bbb4d43'
+prev_migration = '4a7a7dee0718'
+
+from spanner_orm.admin import update
+
+# Returns a SchemaUpdate object that tells what should be changed
+def upgrade():
+  pass
+
+# Returns a SchemaUpdate object that tells how to roll back the changes
+def downgrade():
+  pass

--- a/spanner_orm/tests/migrations/test_2_5c078bbb4d43.py
+++ b/spanner_orm/tests/migrations/test_2_5c078bbb4d43.py
@@ -19,7 +19,7 @@ Created: 2019-02-27 18:52
 """
 
 migration_id = '5c078bbb4d43'
-prev_migration = '4a7a7dee0718'
+prev_migration_id = '4a7a7dee0718'
 
 
 # Returns a SchemaUpdate object that tells what should be changed

--- a/spanner_orm/tests/migrations/test_2_5c078bbb4d43.py
+++ b/spanner_orm/tests/migrations/test_2_5c078bbb4d43.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""test_2
+"""test_2.
 
 Migration ID: 5c078bbb4d43
 Created: 2019-02-27 18:52
@@ -21,11 +21,11 @@ Created: 2019-02-27 18:52
 migration_id = '5c078bbb4d43'
 prev_migration = '4a7a7dee0718'
 
-from spanner_orm.admin import update
 
 # Returns a SchemaUpdate object that tells what should be changed
 def upgrade():
   pass
+
 
 # Returns a SchemaUpdate object that tells how to roll back the changes
 def downgrade():

--- a/spanner_orm/tests/migrations/test_3_eceb25f170dd.py
+++ b/spanner_orm/tests/migrations/test_3_eceb25f170dd.py
@@ -19,7 +19,7 @@ Created: 2019-02-27 18:52
 """
 
 migration_id = 'eceb25f170dd'
-prev_migration = '5c078bbb4d43'
+prev_migration_id = '5c078bbb4d43'
 
 
 # Returns a SchemaUpdate object that tells what should be changed

--- a/spanner_orm/tests/migrations/test_3_eceb25f170dd.py
+++ b/spanner_orm/tests/migrations/test_3_eceb25f170dd.py
@@ -12,18 +12,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""spanner_orm setup file."""
-from setuptools import setup
-setup(
-    name='spanner-orm',
-    version='0.1.8',
-    description='Basic ORM for Spanner',
-    maintainer='Derek Brandao',
-    maintainer_email='dbrandao@google.com',
-    url='https://github.com/google/python-spanner-orm',
-    packages=['spanner_orm', 'spanner_orm.admin'],
-    install_requires=[
-        'google-cloud-spanner >= 1.6, <2.0.0dev'
-    ],
-    tests_require=['absl-py'],
-    entry_points={'console_scripts': ['spanner-orm = spanner_orm.admin.scripts:main']})
+"""test_3
+
+Migration ID: eceb25f170dd
+Created: 2019-02-27 18:52
+"""
+
+migration_id = 'eceb25f170dd'
+prev_migration = '5c078bbb4d43'
+
+from spanner_orm.admin import update
+
+# Returns a SchemaUpdate object that tells what should be changed
+def upgrade():
+  pass
+
+# Returns a SchemaUpdate object that tells how to roll back the changes
+def downgrade():
+  pass

--- a/spanner_orm/tests/migrations/test_3_eceb25f170dd.py
+++ b/spanner_orm/tests/migrations/test_3_eceb25f170dd.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""test_3
+"""test_3.
 
 Migration ID: eceb25f170dd
 Created: 2019-02-27 18:52
@@ -21,11 +21,11 @@ Created: 2019-02-27 18:52
 migration_id = 'eceb25f170dd'
 prev_migration = '5c078bbb4d43'
 
-from spanner_orm.admin import update
 
 # Returns a SchemaUpdate object that tells what should be changed
 def upgrade():
   pass
+
 
 # Returns a SchemaUpdate object that tells how to roll back the changes
 def downgrade():

--- a/spanner_orm/tests/migrations_test.py
+++ b/spanner_orm/tests/migrations_test.py
@@ -1,0 +1,123 @@
+# python3
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import os
+import unittest
+from unittest import mock
+
+from spanner_orm import error
+from spanner_orm import field
+from spanner_orm.admin import migration_manager
+
+
+class TestMigration(object):
+
+  def __init__(self, migration_id, prev_migration):
+    self._id = migration_id
+    self._prev = prev_migration
+
+  @property
+  def migration_id(self):
+    return self._id
+
+  @property
+  def prev_migration(self):
+    return self._prev
+
+  def upgrade(self):
+    pass
+
+  def downgrade(self):
+    pass
+
+
+class MigrationsTest(unittest.TestCase):
+  TEST_DIR = os.path.dirname(__file__)
+  TEST_MIGRATIONS_DIR = os.path.join(TEST_DIR, 'migrations')
+
+  def test_retrieve(self):
+    manager = migration_manager.MigrationManager(self.TEST_MIGRATIONS_DIR)
+    migrations = manager.migrations
+    self.assertEqual(len(migrations), 3)
+    self.assertEqual(migrations[2].prev_migration, migrations[1].migration_id)
+    self.assertEqual(migrations[1].prev_migration, migrations[0].migration_id)
+
+  def test_generate(self):
+    manager = migration_manager.MigrationManager(self.TEST_MIGRATIONS_DIR)
+    try:
+      path = manager.generate('test migration')
+      migration = manager._migration_from_file(path)
+      self.assertIsNotNone(migration.migration_id)
+      self.assertIsNotNone(migration.prev_migration)
+      self.assertIsNotNone(migration.upgrade)
+      self.assertIsNotNone(migration.downgrade)
+    except Exception as ex:
+      raise ex
+    finally:
+      os.remove(path)
+
+  def test_order_migrations(self):
+    first = TestMigration('1', None)
+    second = TestMigration('2', '1')
+    third = TestMigration('3', '2')
+    migrations = [third, first, second]
+    expected_order = [first, second, third]
+
+    manager = migration_manager.MigrationManager(self.TEST_MIGRATIONS_DIR)
+    self.assertEqual(manager._order_migrations(migrations), expected_order)
+
+  def test_order_migrations_with_no_none(self):
+    first = TestMigration('2', '1')
+    second = TestMigration('3', '2')
+    third = TestMigration('4', '3')
+    migrations = [third, first, second]
+    expected_order = [first, second, third]
+
+    manager = migration_manager.MigrationManager(self.TEST_MIGRATIONS_DIR)
+    self.assertEqual(manager._order_migrations(migrations), expected_order)
+
+  def test_order_migrations_error_on_unclear_successor(self):
+    first = TestMigration('1', None)
+    second = TestMigration('2', '1')
+    third = TestMigration('3', '1')
+    migrations = [third, first, second]
+
+    manager = migration_manager.MigrationManager(self.TEST_MIGRATIONS_DIR)
+    with self.assertRaisesRegex(error.SpannerError, 'unclear successor'):
+      manager._order_migrations(migrations)
+
+  def test_order_migrations_error_on_unclear_start_migration(self):
+    first = TestMigration('1', None)
+    second = TestMigration('3', '2')
+    migrations = [first, second]
+
+    manager = migration_manager.MigrationManager(self.TEST_MIGRATIONS_DIR)
+    with self.assertRaisesRegex(error.SpannerError, 'no valid previous'):
+      manager._order_migrations(migrations)
+
+  def test_order_migrations_error_on_circular_dependency(self):
+    first = TestMigration('1', '3')
+    second = TestMigration('2', '1')
+    third = TestMigration('3', '2')
+    migrations = [third, first, second]
+
+    manager = migration_manager.MigrationManager(self.TEST_MIGRATIONS_DIR)
+    with self.assertRaisesRegex(error.SpannerError, 'No valid migration'):
+      manager._order_migrations(migrations)
+
+
+if __name__ == '__main__':
+  logging.basicConfig()
+  unittest.main()

--- a/spanner_orm/tests/migrations_test.py
+++ b/spanner_orm/tests/migrations_test.py
@@ -15,10 +15,8 @@
 import logging
 import os
 import unittest
-from unittest import mock
 
 from spanner_orm import error
-from spanner_orm import field
 from spanner_orm.admin import migration_manager
 
 

--- a/spanner_orm/tests/update_test.py
+++ b/spanner_orm/tests/update_test.py
@@ -22,7 +22,7 @@ from spanner_orm.admin import update
 from spanner_orm.tests import models
 
 
-class MigrationTest(unittest.TestCase):
+class UpdateTest(unittest.TestCase):
 
   @mock.patch('spanner_orm.admin.update.SchemaUpdate._get_model')
   def test_column_update_add_column(self, get_model):

--- a/spanner_orm/tests/update_test.py
+++ b/spanner_orm/tests/update_test.py
@@ -16,7 +16,6 @@ import logging
 import unittest
 from unittest import mock
 
-from spanner_orm import error
 from spanner_orm import field
 from spanner_orm.admin import update
 from spanner_orm.tests import models


### PR DESCRIPTION
Migration files are going to be pretty simple, they contain an id, the
id of the migration the current one depends on, and methods to apply and
rollback the migration that each return a single SchemaUpdate object.
I've added the code to write a migration file, read all migration files,
and order the migrations based on the 'prev_migration' field to
determine what order the migrations have to be applied in.