### PR TITLE
Add code to run migrations against a given Spanner database

### DIFF
--- a/spanner_orm/admin/api.py
+++ b/spanner_orm/admin/api.py
@@ -28,13 +28,13 @@ class SpannerAdminApi(api.SpannerReadApi):
 
   @classmethod
   def connect(cls,
-              project,
               instance,
               database,
+              project=None,
               credentials=None,
               create_ddl=None):
     """Connects to the specified database, optionally creating tables."""
-    connection_info = (project, instance, database, credentials)
+    connection_info = (instance, database, project, credentials)
     if cls._spanner_connection is not None:
       if connection_info == cls._connection_info:
         return
@@ -72,4 +72,4 @@ class SpannerAdminApi(api.SpannerReadApi):
   @classmethod
   def update_schema(cls, change):
     operation = cls._connection().update_ddl([change])
-    operation.result()
+    return operation.result()

--- a/spanner_orm/admin/metadata.py
+++ b/spanner_orm/admin/metadata.py
@@ -51,6 +51,10 @@ class SpannerMetadata(object):
     return cls._models
 
   @classmethod
+  def model(cls, table_name):
+    return cls.models().get(table_name)
+
+  @classmethod
   def tables(cls):
     """Compiles table information from column schema."""
     if cls._tables is None:
@@ -72,9 +76,9 @@ class SpannerMetadata(object):
     """Compiles index information from index and index columns schemas."""
     if cls._indexes is None:
       # ordinal_position is the position of the column in the indicated index.
-      # Results are ordered by that so the index columns are added in the correct
-      # order. None indicates that the key isn't really a part of the index, so we
-      # skip those
+      # Results are ordered by that so the index columns are added in the
+      # correct order. None indicates that the key isn't really a part of the
+      # index, so we skip those
       index_column_schemas = index_column.IndexColumnSchema.where(
           None, condition.equal_to('table_catalog', ''),
           condition.equal_to('table_schema', ''),

--- a/spanner_orm/admin/migration_executor.py
+++ b/spanner_orm/admin/migration_executor.py
@@ -1,0 +1,195 @@
+# python3
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Handles execution of migrations."""
+import datetime
+import logging
+
+from spanner_orm import api
+from spanner_orm import error
+from spanner_orm.admin import api as admin_api
+from spanner_orm.admin import metadata
+from spanner_orm.admin import migration_manager
+from spanner_orm.admin import migration_status
+from spanner_orm.admin import update
+
+_logger = logging.getLogger(__name__)
+
+
+class MigrationExecutor(object):
+  """Handles execution of migrations."""
+
+  def __init__(self,
+               instance,
+               database,
+               project=None,
+               credentials=None,
+               basedir=None):
+    self._manager = migration_manager.MigrationManager(basedir)
+    self._migration_status_map = None
+    self._instance = instance
+    self._database = database
+    self._project = project
+    self._credentials = credentials
+
+  def migrated(self, migration_id):
+    if migration_id is None:
+      return True
+    return self._migration_status().get(migration_id, False)
+
+  def migrations(self):
+    return self._manager.migrations
+
+  def migrate(self, target_migration=None):
+    """Executes unmigrated migrations on the curent database.
+
+    Note: SpannerApi and SpannerAdminApi connections are modified as a result
+    of calling this method. Don't attempt to do other things with spanner_orm
+    in the same process while this method is executing.
+
+    Args:
+      target_migration: If present, stop migrations after the target is
+        executed. If None (default), executes all unmigrated migrations
+    """
+    self._connect()
+    self._validate_migrations()
+    # Filter to unmigrated migrations
+    migrations = self._filter_migrations(self.migrations(), False,
+                                         target_migration)
+    for migration in migrations:
+      _logger.info('Processing migration %s', migration.migration_id)
+      schema_update = migration.upgrade()
+      if not isinstance(schema_update, update.SchemaUpdate):
+        raise error.SpannerError(
+            'Migration {} did not return a SchemaUpdate'.format(
+                migration.migration_id))
+      schema_update.execute()
+
+      self._update_status(migration.migration_id, True)
+    self._hangup()
+
+  def rollback(self, target_migration):
+    """Rolls back migrated migrations on the curent database.
+
+    Note: SpannerApi and SpannerAdminApi connections are modified as a result
+    of calling this method. Don't attempt to do other things with spanner_orm
+    in the same process while this method is executing.
+
+    Args:
+      target_migration: Stop rolling back migrations after this migration is
+        rolled back. Must be present in list of migrated migrations.
+    """
+    self._connect()
+    if not target_migration:
+      raise error.SpannerError('Must specify a migration to roll back')
+
+    self._validate_migrations()
+    # Filter to migrated migrations from most recently applied
+    migrations = self._filter_migrations(
+        reversed(self.migrations()), True, target_migration)
+    for migration in migrations:
+      _logger.info('Processing migration %s', migration.migration_id)
+      schema_update = migration.downgrade()
+      if not isinstance(schema_update, update.SchemaUpdate):
+        raise error.SpannerError(
+            'Migration {} did not return a SchemaUpdate'.format(
+                migration.migration_id))
+      schema_update.execute()
+
+      self._update_status(migration.migration_id, False)
+    self._hangup()
+
+  def _connect(self):
+    admin_api.SpannerAdminApi.connect(
+        self._instance,
+        self._database,
+        project=self._project,
+        credentials=self._credentials)
+    api.SpannerApi.connect(
+        self._instance,
+        self._database,
+        project=self._project,
+        credentials=self._credentials)
+
+  def _hangup(self):
+    admin_api.SpannerAdminApi.hangup()
+    api.SpannerApi.hangup()
+
+  def _filter_migrations(self, migrations, migrated, last_migration):
+    """Filters the list of migrations according to the desired conditions.
+
+    Args:
+      migrations: List of migrations to filter
+      migrated: Only add migrations whose migration status matches this flag
+      last_migration: Stop adding migrations to the list after this one is found
+    """
+    filtered = []
+    last_migration_found = False
+    for migration in migrations:
+      if self.migrated(migration.migration_id) == migrated:
+        filtered.append(migration)
+
+        if last_migration and migration.migration_id == last_migration:
+          last_migration_found = True
+          break
+
+    if last_migration and not last_migration_found:
+      raise error.SpannerError(
+          '{} already has desired status or does not exist'.format(
+              last_migration))
+    return filtered
+
+  def _migration_status(self):
+    """Gathers from Spanner which migrations have been executed."""
+    if self._migration_status_map is None:
+      model_from_db = metadata.SpannerMetadata.model(
+          migration_status.MigrationStatus.table)
+      if not model_from_db:
+        update.CreateTableUpdate(migration_status.MigrationStatus).execute()
+      self._migration_status_map = {
+          migration.id: migration.migrated
+          for migration in migration_status.MigrationStatus.all()
+      }
+
+    return self._migration_status_map
+
+  def _update_status(self, migration_id, new_status):
+    """Updates migration status in the database for the given migration."""
+    new_model = migration_status.MigrationStatus({
+        'id': migration_id,
+        'migrated': new_status,
+        'update_time': datetime.datetime.utcnow(),
+    })
+    migration_status.MigrationStatus.save_batch(
+        None, [new_model], force_write=True)
+    self._migration_status()[migration_id] = new_status
+
+  def _validate_migrations(self):
+    """Validates the migration status of all migrations makes sense."""
+    migrations = self.migrations()
+    if not migrations:
+      return
+
+    first = migrations[0]
+    if not self.migrated(first.prev_migration_id):
+      raise error.SpannerError(
+          'First migration {} depends on unmigrated migration {}'.format(
+              first.migration_id, first.prev_migration_id))
+
+    for migration in migrations:
+      if (self.migrated(migration.migration_id) and
+          not self.migrated(migration.prev_migration_id)):
+        raise error.SpannerError(
+            'Migrated migration {} depends on an unmigrated migration'.format(
+                migration.migration_id))

--- a/spanner_orm/admin/migration_status.py
+++ b/spanner_orm/admin/migration_status.py
@@ -1,0 +1,25 @@
+# python3
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Indicates whether a migration has been applied to the current database."""
+
+from spanner_orm import field
+from spanner_orm import model
+
+
+class MigrationStatus(model.Model):
+  __table__ = 'spanner_orm_migrations'
+  id = field.Field(field.String, primary_key=True)
+  migrated = field.Field(field.Boolean)
+  update_time = field.Field(field.Timestamp)

--- a/spanner_orm/api.py
+++ b/spanner_orm/api.py
@@ -25,7 +25,7 @@ _logger = logging.getLogger(__name__)
 
 
 class SpannerReadApi(abc.ABC):
-  """Handles sending read requests to Spanner"""
+  """Handles sending read requests to Spanner."""
 
   @classmethod
   @abc.abstractmethod
@@ -42,8 +42,8 @@ class SpannerReadApi(abc.ABC):
   @staticmethod
   def find(transaction, table_name, columns, keyset):
     """Obtains rows with primary_keys from the given table."""
-    _logger.debug('Find table=%s columns=%s keys=%s',
-                  table_name, columns, keyset.keys)
+    _logger.debug('Find table=%s columns=%s keys=%s', table_name, columns,
+                  keyset.keys)
     stream_results = transaction.read(
         table=table_name, columns=columns, keyset=keyset)
     return list(stream_results)
@@ -51,8 +51,8 @@ class SpannerReadApi(abc.ABC):
   @staticmethod
   def sql_query(transaction, query, parameters, parameter_types):
     """Runs a read only SQL query."""
-    _logger.debug('Executing SQL:\n%s\n%s\n%s',
-                  query, parameters, parameter_types)
+    _logger.debug('Executing SQL:\n%s\n%s\n%s', query, parameters,
+                  parameter_types)
     stream_results = transaction.execute_sql(
         query, params=parameters, param_types=parameter_types)
     return list(stream_results)
@@ -80,22 +80,22 @@ class SpannerWriteApi(abc.ABC):
   @staticmethod
   def insert(transaction, table_name, columns, values):
     """Add rows to a table."""
-    _logger.debug('Insert table=%s columns=%s values=%s',
-                  table_name, columns, values)
+    _logger.debug('Insert table=%s columns=%s values=%s', table_name, columns,
+                  values)
     transaction.insert(table=table_name, columns=columns, values=values)
 
   @staticmethod
   def update(transaction, table_name, columns, values):
     """Updates rows of a table."""
-    _logger.debug('Update table=%s columns=%s values=%s',
-                  table_name, columns, values)
+    _logger.debug('Update table=%s columns=%s values=%s', table_name, columns,
+                  values)
     transaction.update(table=table_name, columns=columns, values=values)
 
   @staticmethod
   def upsert(transaction, table_name, columns, values):
     """Updates existing rows of a table or adds rows if they don't exist."""
-    _logger.debug('Upsert table=%s columns=%s values=%s',
-                  table_name, columns, values)
+    _logger.debug('Upsert table=%s columns=%s values=%s', table_name, columns,
+                  values)
     transaction.insert_or_update(
         table=table_name, columns=columns, values=values)
 
@@ -114,9 +114,14 @@ class SpannerApi(SpannerReadApi, SpannerWriteApi):
 
   # Spanner connection methods
   @classmethod
-  def connect(cls, project, instance, database, credentials=None, pool=None):
+  def connect(cls,
+              instance,
+              database,
+              project=None,
+              credentials=None,
+              pool=None):
     """Connects to the specified Spanner database."""
-    connection_info = (project, instance, database, credentials)
+    connection_info = (instance, database, project, credentials)
     if cls._spanner_connection is not None:
       if connection_info == cls._connection_info:
         return

--- a/spanner_orm/tests/update_test.py
+++ b/spanner_orm/tests/update_test.py
@@ -19,11 +19,12 @@ from unittest import mock
 from spanner_orm import field
 from spanner_orm.admin import update
 from spanner_orm.tests import models
+from spanner_orm.admin import metadata
 
 
 class UpdateTest(unittest.TestCase):
 
-  @mock.patch('spanner_orm.admin.update.SchemaUpdate._get_model')
+  @mock.patch('spanner_orm.admin.metadata.SpannerMetadata.model')
   def test_column_update_add_column(self, get_model):
     get_model.return_value = models.SmallTestModel
     new_field = field.Field(field.String, nullable=True)
@@ -33,7 +34,7 @@ class UpdateTest(unittest.TestCase):
                      'ALTER TABLE foo ADD COLUMN bar STRING(MAX)')
 
   @mock.patch('spanner_orm.admin.index_column.IndexColumnSchema.count')
-  @mock.patch('spanner_orm.admin.update.SchemaUpdate._get_model')
+  @mock.patch('spanner_orm.admin.metadata.SpannerMetadata.model')
   def test_column_update_error_on_primary_key(self, get_model, index_count):
     index_count.return_value = 1
     get_model.return_value = models.SmallTestModel
@@ -41,14 +42,14 @@ class UpdateTest(unittest.TestCase):
     with self.assertRaisesRegex(AssertionError, 'indexed column'):
       test_update.validate()
 
-  @mock.patch('spanner_orm.admin.update.SchemaUpdate._get_model')
+  @mock.patch('spanner_orm.admin.metadata.SpannerMetadata.model')
   def test_create_table(self, get_model):
     get_model.return_value = None
     new_model = models.SmallTestModel
     test_update = update.CreateTableUpdate(new_model)
     self.assertEqual(test_update.ddl(), new_model.creation_ddl)
 
-  @mock.patch('spanner_orm.admin.update.SchemaUpdate._get_model')
+  @mock.patch('spanner_orm.admin.metadata.SpannerMetadata.model')
   def test_create_table_error_on_existing_table(self, get_model):
     get_model.return_value = models.SmallTestModel
     new_model = models.SmallTestModel


### PR DESCRIPTION
After migrations are written, they need to be run against a given
database to be applied. I've added a model to store the migration status
of migrations on the current database and then wrote the executor to
figure out which migrations need to be executed (both for upgrading and
downgrading migrations), execute them, and then update the database to
indicate that the migration has been run.
In talking with @dseomn, I realized that 'project' can be inferred by
the Spanner client libraries, so I've moved that to be an optional
parameter.