### PR TITLE
Update metadata to work with interleaved tables

### DIFF
--- a/spanner_orm/admin/metadata.py
+++ b/spanner_orm/admin/metadata.py
@@ -22,6 +22,7 @@ from spanner_orm import model
 from spanner_orm.admin import column
 from spanner_orm.admin import index
 from spanner_orm.admin import index_column
+from spanner_orm.admin import table
 
 
 class SpannerMetadata(object):
@@ -36,25 +37,34 @@ class SpannerMetadata(object):
     if cls._models is None:
       tables = cls.tables()
       indexes = cls.indexes()
-      results = {}
+      models = {}
 
-      for table_name, fields in tables.items():
-        primary_index = indexes[table_name]['PRIMARY_KEY']['columns']
+      for table_name, table_data in tables.items():
+        primary_index = set(indexes[table_name]['PRIMARY_KEY']['columns'])
         klass = model.ModelBase('Model_{}'.format(table_name), (model.Model,),
                                 {})
-        for f in fields.values():
-          if f.name in primary_index:
-            f._primary_key = True  # pylint: disable=protected-access
-        klass.meta = model.Metadata(table=table_name, fields=fields)
-        results[table_name] = klass
-      cls._models = results
+        fields = table_data['fields']
+        for field in fields.values():
+          if field.name in primary_index:
+            field._primary_key = True  # pylint: disable=protected-access
+        klass.meta = model.Metadata(
+            table=table_name,
+            fields=fields,
+            interleaved=table_data['parent_table'])
+        models[table_name] = klass
+
+      for table_model in models.values():
+        if table_model.meta.interleaved:
+          table_model.meta.interleaved = models[table_model.meta.interleaved]
+
+      cls._models = models
     return cls._models
 
   @classmethod
   def tables(cls):
     """Compiles table information from column schema."""
     if cls._tables is None:
-      tables = collections.defaultdict(dict)
+      column_data = collections.defaultdict(dict)
       columns = column.ColumnSchema.where(
           None, condition.equal_to('table_catalog', ''),
           condition.equal_to('table_schema', ''))
@@ -63,8 +73,17 @@ class SpannerMetadata(object):
             column_row.field_type(), nullable=column_row.nullable())
         new_field.name = column_row.column_name
         new_field.index = column_row.ordinal_position
-        tables[column_row.table_name][column_row.column_name] = new_field
-      cls._tables = tables
+        column_data[column_row.table_name][column_row.column_name] = new_field
+
+      table_data = collections.defaultdict(dict)
+      tables = table.TableSchema.where(
+          None, condition.equal_to('table_catalog', ''),
+          condition.equal_to('table_schema', ''))
+      for table_row in tables:
+        name = table_row.table_name
+        table_data[name]['parent_table'] = table_row.parent_table_name
+        table_data[name]['fields'] = column_data[name]
+      cls._tables = table_data
     return cls._tables
 
   @classmethod

--- a/spanner_orm/admin/table.py
+++ b/spanner_orm/admin/table.py
@@ -1,0 +1,29 @@
+# python3
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Model for interacting with Spanner column schema table."""
+
+from spanner_orm import field
+from spanner_orm.admin import schema
+
+
+class TableSchema(schema.Schema):
+  """Model for interacting with Spanner column schema table."""
+
+  __table__ = 'information_schema.tables'
+  table_catalog = field.Field(field.String, primary_key=True)
+  table_schema = field.Field(field.String, primary_key=True)
+  table_name = field.Field(field.String, primary_key=True)
+  parent_table_name = field.Field(field.String, nullable=True)
+  on_delete_action = field.Field(field.String, nullable=True)

--- a/spanner_orm/tests/admin_test.py
+++ b/spanner_orm/tests/admin_test.py
@@ -19,19 +19,30 @@ from unittest import mock
 from spanner_orm.admin import column
 from spanner_orm.admin import index
 from spanner_orm.admin import index_column
+from spanner_orm.admin import table
 from spanner_orm.admin import metadata
 from spanner_orm.tests import models
 
 
 class AdminTest(unittest.TestCase):
 
-  def smalltestmodel_columns(self):
+  def make_test_tables(self, model, parent_table=None):
+    tables = [{
+        'table_catalog': '',
+        'table_schema': '',
+        'table_name': model.table,
+        'parent_table_name': parent_table,
+        'on_delete_action': None
+    }]
+    return [table.TableSchema(row) for row in tables]
+
+  def make_test_columns(self, model):
     columns, iteration = [], 1
-    for row in models.SmallTestModel.schema.values():
+    for row in model.schema.values():
       columns.append({
           'table_catalog': '',
           'table_schema': '',
-          'table_name': models.SmallTestModel.table,
+          'table_name': model.table,
           'column_name': row.name,
           'ordinal_position': iteration,
           'is_nullable': 'YES' if row.nullable() else 'NO',
@@ -40,13 +51,13 @@ class AdminTest(unittest.TestCase):
       iteration += 1
     return [column.ColumnSchema(row) for row in columns]
 
-  def smalltestmodel_index_columns(self):
+  def make_test_index_columns(self, model):
     columns = []
-    for row in models.SmallTestModel.primary_keys:
+    for row in model.primary_keys:
       columns.append({
           'table_catalog': '',
           'table_schema': '',
-          'table_name': models.SmallTestModel.table,
+          'table_name': model.table,
           'index_name': 'PRIMARY_KEY',
           'column_name': row,
           'is_nullable': 'FALSE',
@@ -54,12 +65,12 @@ class AdminTest(unittest.TestCase):
       })
     return [index_column.IndexColumnSchema(row) for row in columns]
 
-  def smalltestmodel_indexes(self):
+  def make_test_indexes(self, model):
     return [
         index.IndexSchema({
             'table_catalog': '',
             'table_schema': '',
-            'table_name': models.SmallTestModel.table,
+            'table_name': model.table,
             'index_name': 'PRIMARY_KEY',
             'index_type': 'PRIMARY_KEY',
             'is_unique': True,
@@ -71,23 +82,44 @@ class AdminTest(unittest.TestCase):
   @mock.patch('spanner_orm.admin.index.IndexSchema.where')
   @mock.patch('spanner_orm.admin.index_column.IndexColumnSchema.where')
   @mock.patch('spanner_orm.admin.column.ColumnSchema.where')
-  def test_metadata(self, columns, index_columns, indexes):
+  @mock.patch('spanner_orm.admin.table.TableSchema.where')
+  def test_metadata(self, tables, columns, index_columns, indexes):
     model = models.SmallTestModel
-    columns.return_value = self.smalltestmodel_columns()
-    index_columns.return_value = self.smalltestmodel_index_columns()
-    indexes.return_value = self.smalltestmodel_indexes()
+    tables.return_value = self.make_test_tables(model)
+    columns.return_value = self.make_test_columns(model)
+    index_columns.return_value = self.make_test_index_columns(model)
+    indexes.return_value = self.make_test_indexes(model)
 
-    meta = metadata.SpannerMetadata.models()['SmallTestModel']
+    meta = metadata.SpannerMetadata.models()[model.table]
 
-    self.assertEqual(meta.table, models.SmallTestModel.table)
+    self.assertEqual(meta.table, model.table)
     self.assertEqual(meta.columns, model.columns)
     for row in model.columns:
       self.assertEqual(meta.schema[row].field_type(),
                        model.schema[row].field_type())
       self.assertEqual(meta.schema[row].nullable(),
                        model.schema[row].nullable())
-    self.assertEqual(meta.primary_keys,
-                     models.SmallTestModel.primary_keys)
+    self.assertEqual(meta.primary_keys, model.primary_keys)
+
+  @mock.patch('spanner_orm.admin.index.IndexSchema.where')
+  @mock.patch('spanner_orm.admin.index_column.IndexColumnSchema.where')
+  @mock.patch('spanner_orm.admin.column.ColumnSchema.where')
+  @mock.patch('spanner_orm.admin.table.TableSchema.where')
+  def test_interleaved(self, tables, columns, index_columns, indexes):
+    model = models.SmallTestModel
+    parent_model = models.UnittestModel
+    tables.return_value = (
+        self.make_test_tables(model, parent_table=parent_model.table) +
+        self.make_test_tables(parent_model))
+    columns.return_value = (
+        self.make_test_columns(model) + self.make_test_columns(parent_model))
+    index_columns.return_value = (self.make_test_index_columns(model) + self.make_test_index_columns(parent_model))
+    indexes.return_value = (self.make_test_indexes(model) + self.make_test_indexes(parent_model))
+
+    meta = metadata.SpannerMetadata.models()['SmallTestModel']
+
+    self.assertEqual(meta.table, model.table)
+    self.assertEqual(meta.interleaved.table, parent_model.table)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I had only implemented the write half of this previously. This adds the
read half of handling interleaved tables. That information is stored in
the INFORMATION_SCHEMA.TABLES table, so I've added that model and then
update the metadata object based on the loaded information.