### PR TITLE
Refactor updates and add index-related updates

### DIFF
--- a/spanner_orm/admin/metadata.py
+++ b/spanner_orm/admin/metadata.py
@@ -28,41 +28,36 @@ from spanner_orm.admin import table
 
 class SpannerMetadata(object):
   """Gathers information about a table from Spanner."""
-  _models = None
-  _tables = None
-  _indexes = None
 
   @classmethod
   def models(cls):
     """Constructs model classes from Spanner table schema."""
-    if cls._models is None:
-      tables = cls.tables()
-      indexes = cls.indexes()
-      models = {}
+    tables = cls.tables()
+    indexes = cls.indexes()
+    models = {}
 
-      for table_name, table_data in tables.items():
-        primary_index = indexes[table_name][index.Index.PRIMARY_INDEX]
-        primary_keys = set(primary_index.columns)
-        klass = model.ModelBase('Model_{}'.format(table_name), (model.Model,),
-                                {})
-        for field in table_data['fields'].values():
-          field._primary_key = field.name in primary_keys  # pylint: disable=protected-access
+    for table_name, table_data in tables.items():
+      primary_index = indexes[table_name][index.Index.PRIMARY_INDEX]
+      primary_keys = set(primary_index.columns)
+      klass = model.ModelBase('Model_{}'.format(table_name), (model.Model,),
+                              {})
+      for field in table_data['fields'].values():
+        field._primary_key = field.name in primary_keys  # pylint: disable=protected-access
 
-        klass.meta = model.Metadata(
-            table=table_name,
-            fields=table_data['fields'],
-            interleaved=table_data['parent_table'],
-            indexes=indexes[table_name],
-            model_class=klass)
-        models[table_name] = klass
+      klass.meta = model.Metadata(
+          table=table_name,
+          fields=table_data['fields'],
+          interleaved=table_data['parent_table'],
+          indexes=indexes[table_name],
+          model_class=klass)
+      models[table_name] = klass
 
-      for table_model in models.values():
-        if table_model.meta.interleaved:
-          table_model.meta.interleaved = models[table_model.meta.interleaved]
-        table_model.meta.finalize()
+    for table_model in models.values():
+      if table_model.meta.interleaved:
+        table_model.meta.interleaved = models[table_model.meta.interleaved]
+      table_model.meta.finalize()
 
-      cls._models = models
-    return cls._models
+    return models
 
   @classmethod
   def model(cls, table_name):
@@ -71,63 +66,58 @@ class SpannerMetadata(object):
   @classmethod
   def tables(cls):
     """Compiles table information from column schema."""
-    if cls._tables is None:
-      column_data = collections.defaultdict(dict)
-      columns = column.ColumnSchema.where(
-          None, condition.equal_to('table_catalog', ''),
-          condition.equal_to('table_schema', ''))
-      for column_row in columns:
-        new_field = field.Field(
-            column_row.field_type(), nullable=column_row.nullable())
-        new_field.name = column_row.column_name
-        new_field.position = column_row.ordinal_position
-        column_data[column_row.table_name][column_row.column_name] = new_field
+    column_data = collections.defaultdict(dict)
+    columns = column.ColumnSchema.where(
+        None, condition.equal_to('table_catalog', ''),
+        condition.equal_to('table_schema', ''))
+    for column_row in columns:
+      new_field = field.Field(
+          column_row.field_type(), nullable=column_row.nullable())
+      new_field.name = column_row.column_name
+      new_field.position = column_row.ordinal_position
+      column_data[column_row.table_name][column_row.column_name] = new_field
 
-      table_data = collections.defaultdict(dict)
-      tables = table.TableSchema.where(
-          None, condition.equal_to('table_catalog', ''),
-          condition.equal_to('table_schema', ''))
-      for table_row in tables:
-        name = table_row.table_name
-        table_data[name]['parent_table'] = table_row.parent_table_name
-        table_data[name]['fields'] = column_data[name]
-      cls._tables = table_data
-    return cls._tables
+    table_data = collections.defaultdict(dict)
+    tables = table.TableSchema.where(
+        None, condition.equal_to('table_catalog', ''),
+        condition.equal_to('table_schema', ''))
+    for table_row in tables:
+      name = table_row.table_name
+      table_data[name]['parent_table'] = table_row.parent_table_name
+      table_data[name]['fields'] = column_data[name]
+    return table_data
 
   @classmethod
   def indexes(cls):
     """Compiles index information from index and index columns schemas."""
-    if cls._indexes is None:
-      # ordinal_position is the position of the column in the indicated index.
-      # Results are ordered by that so the index columns are added in the
-      # correct order.
-      index_column_schemas = index_column.IndexColumnSchema.where(
-          None, condition.equal_to('table_catalog', ''),
-          condition.equal_to('table_schema', ''),
-          condition.order_by(('ordinal_position', condition.OrderType.ASC)))
+    # ordinal_position is the position of the column in the indicated index.
+    # Results are ordered by that so the index columns are added in the
+    # correct order.
+    index_column_schemas = index_column.IndexColumnSchema.where(
+        None, condition.equal_to('table_catalog', ''),
+        condition.equal_to('table_schema', ''),
+        condition.order_by(('ordinal_position', condition.OrderType.ASC)))
 
-      index_columns = collections.defaultdict(list)
-      storing_columns = collections.defaultdict(list)
-      for schema in index_column_schemas:
-        key = (schema.table_name, schema.index_name)
-        if schema.ordinal_position is not None:
-          index_columns[key].append(schema.column_name)
-        else:
-          storing_columns[key].append(schema.column_name)
+    index_columns = collections.defaultdict(list)
+    storing_columns = collections.defaultdict(list)
+    for schema in index_column_schemas:
+      key = (schema.table_name, schema.index_name)
+      if schema.ordinal_position is not None:
+        index_columns[key].append(schema.column_name)
+      else:
+        storing_columns[key].append(schema.column_name)
 
-      index_schemas = index_schema.IndexSchema.where(
-          None, condition.equal_to('table_catalog', ''),
-          condition.equal_to('table_schema', ''))
-      indexes = collections.defaultdict(dict)
-      for schema in index_schemas:
-        key = (schema.table_name, schema.index_name)
-        indexes[schema.table_name][schema.index_name] = index.Index(
-            index_columns[key],
-            schema.index_name,
-            parent=schema.parent_table_name,
-            null_filtered=schema.is_null_filtered,
-            unique=schema.is_unique,
-            storing_columns=storing_columns[key])
-      cls._indexes = indexes
-
-    return cls._indexes
+    index_schemas = index_schema.IndexSchema.where(
+        None, condition.equal_to('table_catalog', ''),
+        condition.equal_to('table_schema', ''))
+    indexes = collections.defaultdict(dict)
+    for schema in index_schemas:
+      key = (schema.table_name, schema.index_name)
+      indexes[schema.table_name][schema.index_name] = index.Index(
+          index_columns[key],
+          schema.index_name,
+          parent=schema.parent_table_name,
+          null_filtered=schema.is_null_filtered,
+          unique=schema.is_unique,
+          storing_columns=storing_columns[key])
+    return indexes

--- a/spanner_orm/tests/admin_test.py
+++ b/spanner_orm/tests/admin_test.py
@@ -27,11 +27,6 @@ from spanner_orm.tests import models
 
 class AdminTest(unittest.TestCase):
 
-  def clear_metadata(self):
-    metadata.SpannerMetadata._models = None
-    metadata.SpannerMetadata._indexes = None
-    metadata.SpannerMetadata._tables = None
-
   def make_test_tables(self, model, parent_table=None):
     tables = [{
         'table_catalog': '',
@@ -102,7 +97,6 @@ class AdminTest(unittest.TestCase):
   @mock.patch('spanner_orm.admin.column.ColumnSchema.where')
   @mock.patch('spanner_orm.admin.table.TableSchema.where')
   def test_metadata(self, tables, columns, index_columns, indexes):
-    self.clear_metadata()
     model = models.SmallTestModel
     tables.return_value = self.make_test_tables(model)
     columns.return_value = self.make_test_columns(model)
@@ -127,7 +121,6 @@ class AdminTest(unittest.TestCase):
   @mock.patch('spanner_orm.admin.column.ColumnSchema.where')
   @mock.patch('spanner_orm.admin.table.TableSchema.where')
   def test_interleaved(self, tables, columns, index_columns, indexes):
-    self.clear_metadata()
     model = models.SmallTestModel
     parent_model = models.UnittestModel
     tables.return_value = (
@@ -151,7 +144,6 @@ class AdminTest(unittest.TestCase):
   @mock.patch('spanner_orm.admin.column.ColumnSchema.where')
   @mock.patch('spanner_orm.admin.table.TableSchema.where')
   def test_secondary_index(self, tables, columns, index_columns, indexes):
-    self.clear_metadata()
     model = models.SmallTestModel
     name = 'secondary_index'
     index_cols = ['value_1']

--- a/spanner_orm/tests/update_test.py
+++ b/spanner_orm/tests/update_test.py
@@ -16,6 +16,7 @@ import logging
 import unittest
 from unittest import mock
 
+from spanner_orm import error
 from spanner_orm import field
 from spanner_orm.admin import update
 from spanner_orm.tests import models
@@ -25,37 +26,80 @@ from spanner_orm.admin import metadata
 class UpdateTest(unittest.TestCase):
 
   @mock.patch('spanner_orm.admin.metadata.SpannerMetadata.model')
-  def test_column_update_add_column(self, get_model):
+  def test_add_column(self, get_model):
+    table_name = models.SmallTestModel.table
     get_model.return_value = models.SmallTestModel
+
     new_field = field.Field(field.String, nullable=True)
-    test_update = update.ColumnUpdate('foo', 'bar', new_field)
+    test_update = update.AddColumn(table_name, 'bar', new_field)
     test_update.validate()
-    self.assertEqual(test_update.ddl(),
-                     'ALTER TABLE foo ADD COLUMN bar STRING(MAX)')
+    self.assertEqual(
+        test_update.ddl(),
+        'ALTER TABLE {} ADD COLUMN bar STRING(MAX)'.format(table_name))
 
   @mock.patch('spanner_orm.admin.index_column.IndexColumnSchema.count')
   @mock.patch('spanner_orm.admin.metadata.SpannerMetadata.model')
-  def test_column_update_error_on_primary_key(self, get_model, index_count):
-    index_count.return_value = 1
+  def test_drop_column(self, get_model, index_count):
+    table_name = models.SmallTestModel.table
     get_model.return_value = models.SmallTestModel
-    test_update = update.ColumnUpdate(models.SmallTestModel.table, 'key', None)
-    with self.assertRaisesRegex(AssertionError, 'indexed column'):
+    index_count.return_value = 0
+
+    new_field = field.Field(field.String, nullable=True)
+    test_update = update.DropColumn(table_name, 'value_2')
+    test_update.validate()
+    self.assertEqual(test_update.ddl(),
+                     'ALTER TABLE {} DROP COLUMN value_2'.format(table_name))
+
+  @mock.patch('spanner_orm.admin.index_column.IndexColumnSchema.count')
+  @mock.patch('spanner_orm.admin.metadata.SpannerMetadata.model')
+  def test_drop_column_error_on_primary_key(self, get_model, index_count):
+    get_model.return_value = models.SmallTestModel
+    index_count.return_value = 1
+
+    test_update = update.DropColumn(models.SmallTestModel.table, 'key')
+    with self.assertRaisesRegex(error.SpannerError, 'Column key is indexed'):
       test_update.validate()
 
   @mock.patch('spanner_orm.admin.metadata.SpannerMetadata.model')
   def test_create_table(self, get_model):
     get_model.return_value = None
     new_model = models.SmallTestModel
-    test_update = update.CreateTableUpdate(new_model)
+    test_update = update.CreateTable(new_model)
+    test_update.validate()
     self.assertEqual(test_update.ddl(), new_model.creation_ddl)
 
   @mock.patch('spanner_orm.admin.metadata.SpannerMetadata.model')
   def test_create_table_error_on_existing_table(self, get_model):
     get_model.return_value = models.SmallTestModel
     new_model = models.SmallTestModel
-    test_update = update.CreateTableUpdate(new_model)
-    with self.assertRaisesRegex(AssertionError, 'already exists'):
+    test_update = update.CreateTable(new_model)
+    with self.assertRaisesRegex(error.SpannerError, 'already exists'):
       test_update.validate()
+
+  @mock.patch('spanner_orm.admin.metadata.SpannerMetadata.indexes')
+  @mock.patch('spanner_orm.admin.metadata.SpannerMetadata.tables')
+  @mock.patch('spanner_orm.admin.metadata.SpannerMetadata.model')
+  def test_drop_table(self, get_model, tables, indexes):
+    table_name = models.SmallTestModel.table
+    get_model.return_value = models.SmallTestModel
+    tables.return_value = {}
+    indexes.return_value = {}
+
+    test_update = update.DropTable(table_name)
+    test_update.validate()
+    self.assertEqual(test_update.ddl(), 'DROP TABLE {}'.format(table_name))
+
+  @mock.patch('spanner_orm.admin.metadata.SpannerMetadata.model')
+  def test_add_index(self, get_model):
+    table_name = models.SmallTestModel.table
+    get_model.return_value = models.SmallTestModel
+
+    test_update = update.CreateIndex(table_name, 'foo', ['value_1'])
+    test_update.validate()
+    self.assertEqual(
+        test_update.ddl(),
+        'CREATE INDEX foo ON {} (value_1)'.format(table_name))
+
 
 if __name__ == '__main__':
   logging.basicConfig()


### PR DESCRIPTION
- Separated out the different types of updates that had been jammed into
one type. ColumnUpdate now AddColumn/DropColumn/AlterColumn, IndexUpdate
now AddIndex/DropIndex.
- Switched from assertions to SpannerErrors, made error messages more
consistent and helpful
- Implemented DropTable updates
- Implemented AddIndex and DropIndex updates
- I tested this in a Python shell and realized that the metadata caching
was incompatible with migrations (as the metadata changes after a
migration is run), so I removed that