### PR TITLE
Make model specification and loading more robust

### DIFF
--- a/spanner_orm/registry.py
+++ b/spanner_orm/registry.py
@@ -1,0 +1,67 @@
+# python3
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Registers Model classes so they can be referenced elsewhere."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Type, Union
+
+import dataclasses
+from spanner_orm import error
+
+
+@dataclasses.dataclass
+class RegistryComponent:
+  references: List[Type[Any]] = dataclasses.field(default_factory=list)
+
+  def add(self, reference: Type[Any]) -> None:
+    self.references.append(reference)
+
+
+class Registry(object):
+
+  def __init__(self):
+    self._registered = {}  # type: Dict[str, RegistryComponent]
+
+  def _name_from_class(self, klass: Type[Any]) -> str:
+    return '{}.{}'.format(klass.__module__, klass.__name__)
+
+  def register(self, to_register: Type[Any]) -> None:
+    name_components = reversed(self._name_from_class(to_register).split('.'))
+    name = None
+    for component in name_components:
+      name = name = '{}.{}'.format(component, name) if name else component
+      if name not in self._registered:
+        self._registered[name] = RegistryComponent()
+      self._registered[name].add(to_register)
+
+  def get(self, name: Union[Type[Any], str]) -> Type[Any]:
+    if isinstance(name, type):
+      name = self._name_from_class(name)
+
+    if name not in self._registered:
+      raise error.SpannerError(
+          '{} was not found, verify it has been imported'.format(name))
+    if len(self._registered[name].references) > 1:
+      raise error.SpannerError(
+          'Multiple classes match {}, add more specificity'.format(name))
+    return self._registered[name].references[0]
+
+
+_registry = Registry()
+
+
+def model_registry():
+  return _registry

--- a/spanner_orm/relationship.py
+++ b/spanner_orm/relationship.py
@@ -21,6 +21,7 @@ from typing import Dict, List, Type, Union
 from spanner_orm import condition
 from spanner_orm import error
 from spanner_orm import model
+from spanner_orm import registry
 
 
 class Relationship(object):
@@ -59,7 +60,8 @@ class Relationship(object):
   @property
   def destination(self) -> Type[model.Model]:
     if not self._destination:
-      self._destination = model.load_model(self._destination_handle)
+      self._destination = registry.model_registry().get(
+          self._destination_handle)
     return self._destination
 
   @property
@@ -82,5 +84,4 @@ class Relationship(object):
       conditions.append(
           condition.ColumnsEqualCondition(destination_column, self.origin,
                                           origin_column))
-
     return conditions

--- a/spanner_orm/relationship.py
+++ b/spanner_orm/relationship.py
@@ -94,3 +94,4 @@ class Relationship(object):
                                  self.origin, origin_column))  # type: ignore
 
     return constraints
+  

--- a/spanner_orm/relationship.py
+++ b/spanner_orm/relationship.py
@@ -94,4 +94,3 @@ class Relationship(object):
                                  self.origin, origin_column))  # type: ignore
 
     return constraints
-  

--- a/spanner_orm/tests/model_test.py
+++ b/spanner_orm/tests/model_test.py
@@ -124,6 +124,9 @@ class ModelTest(parameterized.TestCase):
     with self.assertRaises(AttributeError):
       _ = test_model.parent
 
+  def test_interleaved(self):
+    self.assertEqual(models.ChildTestModel.interleaved, models.SmallTestModel)
+
   @mock.patch('spanner_orm.model.ModelMeta.find')
   def test_reload(self, find):
     values = {'key': 'key', 'value_1': 'value_1'}

--- a/spanner_orm/tests/models.py
+++ b/spanner_orm/tests/models.py
@@ -33,7 +33,7 @@ class ChildTestModel(model.Model):
   """Model class for testing interleaved tables."""
 
   __table__ = 'ChildTestModel'
-  __interleaved__ = SmallTestModel
+  __interleaved__ = 'SmallTestModel'
 
   key = field.Field(field.String, primary_key=True)
   child_key = field.Field(field.String, primary_key=True)


### PR DESCRIPTION
Right now, in relationships and parent table specifications, specifying
the model name requires a fully-specified class name. Adding a registry
so we don't have to load classes on the fly and instead register classes
as they load, so we can specify a less-qualified class name and avoid
having to read files to resolve a model class