### PR TITLE
Add type annotations to model metadata

### DIFF
--- a/spanner_orm/admin/metadata.py
+++ b/spanner_orm/admin/metadata.py
@@ -19,6 +19,7 @@ import collections
 from spanner_orm import condition
 from spanner_orm import field
 from spanner_orm import index
+from spanner_orm import metadata
 from spanner_orm import model
 from spanner_orm.admin import column
 from spanner_orm.admin import index as index_schema
@@ -48,7 +49,7 @@ class SpannerMetadata(object):
       for model_field in table_data['fields'].values():
         model_field._primary_key = model_field.name in primary_keys  # pylint: disable=protected-access
 
-      klass.meta = model.Metadata(
+      klass.meta = metadata.ModelMetadata(
           table=table_name,
           fields=table_data['fields'],
           interleaved=cls._class_name_from_table(table_data['parent_table']),

--- a/spanner_orm/metadata.py
+++ b/spanner_orm/metadata.py
@@ -1,0 +1,103 @@
+# python3
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# python3
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Hold information about a Model extracted from the class attributes."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Type, Optional
+
+from spanner_orm import field
+from spanner_orm import index
+from spanner_orm import registry
+from spanner_orm import relationship
+
+
+class ModelMetadata(object):
+  """Hold information about a Model extracted from the class attributes."""
+
+  def __init__(self,
+               table: Optional[str] = None,
+               fields: Optional[Dict[str, field.Field]] = None,
+               relations: Optional[Dict[str, relationship.Relationship]] = None,
+               indexes: Optional[Dict[str, index.Index]] = None,
+               interleaved: Optional[str] = None,
+               model_class: Optional[Type[Any]] = None):
+    self.table = table or ''
+    self.fields = fields or {}
+    self.relations = relations or {}
+    self.indexes = indexes or {}
+    self.interleaved = interleaved
+    self.model_class = model_class
+    self._finalized = False
+
+  def finalize(self) -> None:
+    """Finish generating metadata state.
+
+    Some metadata depends on having all configuration data set before it can
+    be calculated--the primary index, for example, needs all fields to be added
+    before it can be calculated. This method is called to indicate that all
+    relevant state has been added and the calculation of the final data should
+    now happen.
+    """
+    assert not self._finalized
+    sorted_fields = list(sorted(self.fields.values(), key=lambda f: f.position))
+
+    if index.Index.PRIMARY_INDEX not in self.indexes:
+      primary_keys = [f.name for f in sorted_fields if f.primary_key()]
+      primary_index = index.Index(primary_keys)
+      primary_index.name = index.Index.PRIMARY_INDEX
+      self.indexes[index.Index.PRIMARY_INDEX] = primary_index
+    self.primary_keys = self.indexes[index.Index.PRIMARY_INDEX].columns
+
+    self.columns = [f.name for f in sorted_fields]
+
+    for _, relation in self.relations.items():
+      relation.origin = self.model_class
+    registry.model_registry().register(self.model_class)
+    self._finalized = True
+
+  def add_metadata(self, metadata: ModelMetadata) -> None:
+    self.table = metadata.table or self.table
+    self.fields.update(metadata.fields)
+    self.relations.update(metadata.relations)
+    self.interleaved = metadata.interleaved or self.interleaved
+
+  def add_field(self, name: str, new_field: field.Field) -> None:
+    new_field.name = name
+    new_field.position = len(self.fields)
+    self.fields[name] = new_field
+
+  def add_relation(self, name: str,
+                   new_relation: relationship.Relationship) -> None:
+    new_relation.name = name
+    self.relations[name] = new_relation
+
+  def add_index(self, name: str, new_index: index.Index) -> None:
+    new_index.name = name
+    self.indexes[name] = new_index


### PR DESCRIPTION
model.py has gotten pretty big, so split out Metadata into a separate
file and add type annotations to it. Also the Metadata got confusing
with admin SpannerMetadata, so I'm starting to rename things to make
more sense.