### PR TITLE
Add annotations to model metaclass and model API class

### DIFF
--- a/spanner_orm/admin/metadata.py
+++ b/spanner_orm/admin/metadata.py
@@ -44,7 +44,7 @@ class SpannerMetadata(object):
     for table_name, table_data in tables.items():
       primary_index = indexes[table_name][index.Index.PRIMARY_INDEX]
       primary_keys = set(primary_index.columns)
-      klass = model.ModelBase(
+      klass = model.ModelMetaclass(
           cls._class_name_from_table(table_name), (model.Model,), {})
       for model_field in table_data['fields'].values():
         model_field._primary_key = model_field.name in primary_keys  # pylint: disable=protected-access

--- a/spanner_orm/metadata.py
+++ b/spanner_orm/metadata.py
@@ -48,13 +48,15 @@ class ModelMetadata(object):
                indexes: Optional[Dict[str, index.Index]] = None,
                interleaved: Optional[str] = None,
                model_class: Optional[Type[Any]] = None):
-    self.table = table or ''
-    self.fields = fields or {}
-    self.relations = relations or {}
-    self.indexes = indexes or {}
+    self.columns = []
+    self.fields = dict(fields or {})
+    self._finalized = False
+    self.indexes = dict(indexes or {})
     self.interleaved = interleaved
     self.model_class = model_class
-    self._finalized = False
+    self.primary_keys = []
+    self.relations = dict(relations or {})
+    self.table = table or ''
 
   def finalize(self) -> None:
     """Finish generating metadata state.

--- a/spanner_orm/relationship.py
+++ b/spanner_orm/relationship.py
@@ -20,7 +20,6 @@ from typing import Any, Dict, List, Type, Union
 
 import dataclasses
 from spanner_orm import error
-from spanner_orm import model
 from spanner_orm import registry
 
 
@@ -36,7 +35,7 @@ class Relationship(object):
   """Helps define a foreign key relationship between two models."""
 
   def __init__(self,
-               destination_handle: Union[Type[model.Model], str],
+               destination_handle: Union[Type[Any], str],
                constraints: Dict[str, str],
                is_parent: bool = False,
                single: bool = False):
@@ -66,7 +65,7 @@ class Relationship(object):
     return self._parse_constraints()
 
   @property
-  def destination(self) -> Type[model.Model]:
+  def destination(self) -> Type[Any]:
     if not self._destination:
       self._destination = registry.model_registry().get(
           self._destination_handle)

--- a/spanner_orm/tests/model_api_test.py
+++ b/spanner_orm/tests/model_api_test.py
@@ -39,10 +39,12 @@ class ModelApiTest(unittest.TestCase):
     mock_transaction = mock.Mock()
     find.return_value = [['key', 'value_1', None]]
     result = models.SmallTestModel.find(mock_transaction, key='key')
-
-    self.assertEqual(result.key, 'key')
-    self.assertEqual(result.value_1, 'value_1')
-    self.assertIsNone(result.value_2)
+    if result:
+      self.assertEqual(result.key, 'key')
+      self.assertEqual(result.value_1, 'value_1')
+      self.assertIsNone(result.value_2)
+    else:
+      self.fail('Failed to find result')
 
   @mock.patch('spanner_orm.api.SpannerApi.find')
   def test_find_multi_calls_api(self, find):

--- a/spanner_orm/tests/model_test.py
+++ b/spanner_orm/tests/model_test.py
@@ -127,7 +127,7 @@ class ModelTest(parameterized.TestCase):
   def test_interleaved(self):
     self.assertEqual(models.ChildTestModel.interleaved, models.SmallTestModel)
 
-  @mock.patch('spanner_orm.model.ModelMeta.find')
+  @mock.patch('spanner_orm.model.ModelApi.find')
   def test_reload(self, find):
     values = {'key': 'key', 'value_1': 'value_1'}
     model = models.SmallTestModel(values, persisted=False)
@@ -139,7 +139,7 @@ class ModelTest(parameterized.TestCase):
     self.assertIsNone(transaction)
     self.assertEqual(kwargs, model.id())
 
-  @mock.patch('spanner_orm.model.ModelMeta.find')
+  @mock.patch('spanner_orm.model.ModelApi.find')
   def test_reload_reloads(self, find):
     values = {'key': 'key', 'value_1': 'value_1'}
     model = models.SmallTestModel(values, persisted=False)
@@ -149,7 +149,7 @@ class ModelTest(parameterized.TestCase):
     model.reload()
     self.assertEqual(model.value_1, updated_values['value_1'])
 
-  @mock.patch('spanner_orm.model.ModelMeta.create')
+  @mock.patch('spanner_orm.model.ModelApi.create')
   def test_save_creates(self, create):
     values = {'key': 'key', 'value_1': 'value_1'}
     model = models.SmallTestModel(values, persisted=False)
@@ -160,7 +160,7 @@ class ModelTest(parameterized.TestCase):
     self.assertIsNone(transaction)
     self.assertEqual(kwargs, {**values, 'value_2': None})
 
-  @mock.patch('spanner_orm.model.ModelMeta.update')
+  @mock.patch('spanner_orm.model.ModelApi.update')
   def test_save_updates(self, update):
     values = {'key': 'key', 'value_1': 'value_1'}
     model = models.SmallTestModel(values, persisted=True)
@@ -174,7 +174,7 @@ class ModelTest(parameterized.TestCase):
     self.assertIsNone(transaction)
     self.assertEqual(kwargs, values)
 
-  @mock.patch('spanner_orm.model.ModelMeta.update')
+  @mock.patch('spanner_orm.model.ModelApi.update')
   def test_save_no_changes(self, update):
     values = {'key': 'key', 'value_1': 'value_1'}
     model = models.SmallTestModel(values, persisted=True)


### PR DESCRIPTION
Added type annotations to model metaclass and model API class. In order
to make things parse correctly, I had to strip the class holding the
model API methods of its metaclass status, but I mostly just turned the
metaclass methods into regular classmethods.
I had to change the Model typehint in relationship to Any, because
pytype choked on it, for unknown reasons. On the other hand, after this
PR, gpylint and pytype run clean