### PR TITLE
Add migration object for stronger typing

### DIFF
--- a/spanner_orm/__init__.py
+++ b/spanner_orm/__init__.py
@@ -23,6 +23,7 @@ from spanner_orm import field
 from spanner_orm import model
 from spanner_orm import relationship
 from spanner_orm.admin import api as admin_api
+from spanner_orm.admin import update
 
 # add NullHandler to root-module logger so that individual modules
 # won't have to.
@@ -62,3 +63,13 @@ ORDER_DESC = condition.OrderType.DESC
 
 transactional_read = decorator.transactional_read
 transactional_write = decorator.transactional_write
+
+CreateTable = update.CreateTable
+DropTable = update.DropTable
+AddColumn = update.AddColumn
+DropColumn = update.DropColumn
+AlterColumn = update.AlterColumn
+CreateIndex = update.CreateIndex
+DropIndex = update.DropIndex
+NoUpdate = update.NoUpdate
+model_creation_ddl = update.model_creation_ddl

--- a/spanner_orm/admin/migration.py
+++ b/spanner_orm/admin/migration.py
@@ -1,0 +1,55 @@
+# python3
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Holds information about a specific migration."""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from spanner_orm.admin import update
+
+
+def no_update_callable() -> update.SchemaUpdate:
+  return update.NoUpdate()
+
+
+class Migration:
+  """Holds information about a specific migration."""
+
+  def __init__(self,
+               migration_id: str,
+               prev_migration_id: Optional[str],
+               upgrade: Optional[Callable[[], update.SchemaUpdate]] = None,
+               downgrade: Optional[Callable[[], update.SchemaUpdate]] = None):
+    self._id = migration_id
+    self._prev = prev_migration_id
+    self._upgrade = upgrade or no_update_callable
+    self._downgrade = downgrade or no_update_callable
+
+  @property
+  def migration_id(self) -> str:
+    return self._id
+
+  @property
+  def prev_migration_id(self) -> Optional[str]:
+    return self._prev
+
+  @property
+  def upgrade(self) -> Optional[Callable[[], update.SchemaUpdate]]:
+    return self._upgrade
+
+  @property
+  def downgrade(self) -> Optional[Callable[[], update.SchemaUpdate]]:
+    return self._downgrade

--- a/spanner_orm/admin/migration.skel
+++ b/spanner_orm/admin/migration.skel
@@ -4,15 +4,15 @@ Migration ID: $migration_id
 Created: $current_date
 """
 
+import spanner_orm
+
 migration_id = $migration_id
 prev_migration_id = $prev_migration_id
 
-from spanner_orm.admin import update
-
 # Returns a SchemaUpdate object that tells what should be changed
-def upgrade():
-  pass
+def upgrade() -> spanner_orm.NoUpdate:
+  return spanner_orm.NoUpdate()
 
 # Returns a SchemaUpdate object that tells how to roll back the changes
-def downgrade():
-  pass
+def downgrade() -> spanner_orm.NoUpdate:
+  return spanner_orm.NoUpdate()

--- a/spanner_orm/tests/migrations/test_1_4a7a7dee0718.py
+++ b/spanner_orm/tests/migrations/test_1_4a7a7dee0718.py
@@ -18,15 +18,17 @@ Migration ID: 4a7a7dee0718
 Created: 2019-02-27 18:52
 """
 
+import spanner_orm
+
 migration_id = '4a7a7dee0718'
 prev_migration_id = None
 
 
 # Returns a SchemaUpdate object that tells what should be changed
-def upgrade():
-  pass
+def upgrade() -> spanner_orm.NoUpdate:
+  return spanner_orm.NoUpdate()
 
 
 # Returns a SchemaUpdate object that tells how to roll back the changes
-def downgrade():
-  pass
+def downgrade() -> spanner_orm.NoUpdate:
+  return spanner_orm.NoUpdate()

--- a/spanner_orm/tests/migrations/test_2_5c078bbb4d43.py
+++ b/spanner_orm/tests/migrations/test_2_5c078bbb4d43.py
@@ -18,15 +18,17 @@ Migration ID: 5c078bbb4d43
 Created: 2019-02-27 18:52
 """
 
+import spanner_orm
+
 migration_id = '5c078bbb4d43'
 prev_migration_id = '4a7a7dee0718'
 
 
 # Returns a SchemaUpdate object that tells what should be changed
-def upgrade():
-  pass
+def upgrade() -> spanner_orm.NoUpdate:
+  return spanner_orm.NoUpdate()
 
 
 # Returns a SchemaUpdate object that tells how to roll back the changes
-def downgrade():
-  pass
+def downgrade() -> spanner_orm.NoUpdate:
+  return spanner_orm.NoUpdate()

--- a/spanner_orm/tests/migrations/test_3_eceb25f170dd.py
+++ b/spanner_orm/tests/migrations/test_3_eceb25f170dd.py
@@ -18,15 +18,17 @@ Migration ID: eceb25f170dd
 Created: 2019-02-27 18:52
 """
 
+import spanner_orm
+
 migration_id = 'eceb25f170dd'
 prev_migration_id = '5c078bbb4d43'
 
 
 # Returns a SchemaUpdate object that tells what should be changed
-def upgrade():
-  pass
+def upgrade() -> spanner_orm.NoUpdate:
+  return spanner_orm.NoUpdate()
 
 
 # Returns a SchemaUpdate object that tells how to roll back the changes
-def downgrade():
-  pass
+def downgrade() -> spanner_orm.NoUpdate:
+  return spanner_orm.NoUpdate()


### PR DESCRIPTION
Fixing the TODO from #55. In the process, I noticed that the migration
skeleton didn't work properly, so I fixed the imports and the return
value there.
Note: depends on #55 