### PR TITLE
Refactor connection code

### DIFF
--- a/spanner_orm/__init__.py
+++ b/spanner_orm/__init__.py
@@ -30,9 +30,20 @@ from spanner_orm.admin import update
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 # pylint: disable=invalid-name
-SpannerApi = api.SpannerApi
-SpannerAdminApi = admin_api.SpannerAdminApi
+SpannerConnection = api.SpannerConnection
 SpannerError = error.SpannerError
+
+SpannerApi = api.SpannerApi
+connect = api.connect
+from_connection = api.from_connection
+hangup = api.hangup
+spanner_api = api.spanner_api
+
+SpannerAdminApi = admin_api.SpannerAdminApi
+connect_admin = admin_api.connect
+from_admin_connection = admin_api.from_connection
+hangup_admin = admin_api.hangup
+spanner_admin_api = admin_api.spanner_admin_api
 
 Model = model.Model
 

--- a/spanner_orm/admin/migration_status.py
+++ b/spanner_orm/admin/migration_status.py
@@ -18,9 +18,15 @@ from __future__ import annotations
 
 from spanner_orm import field
 from spanner_orm import model
+from spanner_orm.admin import api
 
 
 class MigrationStatus(model.Model):
+
+  @classmethod
+  def spanner_api(cls) -> api.SpannerAdminApi:
+    return api.spanner_admin_api()
+
   __table__ = 'spanner_orm_migrations'
   id = field.Field(field.String, primary_key=True)
   migrated = field.Field(field.Boolean)

--- a/spanner_orm/admin/schema.py
+++ b/spanner_orm/admin/schema.py
@@ -16,15 +16,11 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, NoReturn, Optional, TypeVar
+from typing import NoReturn
 
 from spanner_orm import error
 from spanner_orm import model
 from spanner_orm.admin import api
-
-from google.cloud.spanner_v1 import transaction as spanner_transaction
-
-CallableReturn = TypeVar('CallableReturn')
 
 
 class InformationSchema(model.Model):
@@ -34,13 +30,8 @@ class InformationSchema(model.Model):
   """
 
   @classmethod
-  def _execute_read(cls, db_api: Callable[..., CallableReturn],
-                    transaction: Optional[spanner_transaction.Transaction],
-                    args: Any) -> CallableReturn:
-    if transaction is not None:
-      return db_api(transaction, *args)
-    else:
-      return api.SpannerAdminApi.run_read_only(db_api, *args)
+  def spanner_api(cls) -> api.SpannerAdminApi:
+    return api.spanner_admin_api()
 
   @classmethod
   def _execute_write(cls, *args) -> NoReturn:

--- a/spanner_orm/admin/update.py
+++ b/spanner_orm/admin/update.py
@@ -37,7 +37,7 @@ class SchemaUpdate(abc.ABC):
 
   def execute(self) -> None:
     self.validate()
-    api.SpannerAdminApi.update_schema(self.ddl())
+    api.spanner_admin_api().update_schema(self.ddl())
 
   @abc.abstractmethod
   def validate(self) -> None:

--- a/spanner_orm/tests/api_test.py
+++ b/spanner_orm/tests/api_test.py
@@ -26,35 +26,32 @@ class ApiTest(unittest.TestCase):
   @mock.patch('google.cloud.spanner.Client')
   def test_api_connection(self, client):
     connection = self.mock_connection(client)
-    api.SpannerApi.connect('', '', '')
-    self.assertEqual(api.SpannerApi._connection(), connection)
+    api.connect('', '', '')
+    self.assertEqual(api.spanner_api()._connection, connection)
 
-    api.SpannerApi.hangup()
+    api.hangup()
     with self.assertRaises(error.SpannerError):
-      api.SpannerApi._connection()
+      api.spanner_api()
 
   def test_api_error_when_not_connected(self):
     with self.assertRaises(error.SpannerError):
-      api.SpannerApi.run_read_only(api.SpannerApi.find)
-
-    with self.assertRaises(error.SpannerError):
-      api.SpannerApi.run_write(api.SpannerApi.find)
+      api.spanner_api()
 
   @mock.patch('google.cloud.spanner.Client')
   def test_admin_api_connection(self, client):
     connection = self.mock_connection(client)
-    admin_api.SpannerAdminApi.connect('', '', '')
-    self.assertEqual(admin_api.SpannerAdminApi._connection(), connection)
+    admin_api.connect('', '', '')
+    self.assertEqual(admin_api.spanner_admin_api()._connection, connection)
 
-    admin_api.SpannerAdminApi.hangup()
+    admin_api.hangup()
     with self.assertRaises(error.SpannerError):
-      api.SpannerApi._connection()
+      admin_api.spanner_admin_api()
 
   @mock.patch('google.cloud.spanner.Client')
   def test_admin_api_create_ddl_connection(self, client):
     connection = self.mock_connection(client)
-    admin_api.SpannerAdminApi.connect('', '', '', create_ddl=['create ddl'])
-    self.assertEqual(admin_api.SpannerAdminApi._connection(), connection)
+    admin_api.connect('', '', '', create_ddl=['create ddl'])
+    self.assertEqual(admin_api.spanner_admin_api()._connection, connection)
 
   def mock_connection(self, client):
     connection = mock.Mock()

--- a/spanner_orm/tests/migrations_test.py
+++ b/spanner_orm/tests/migrations_test.py
@@ -109,7 +109,9 @@ class MigrationsTest(unittest.TestCase):
       manager._order_migrations(migrations)
 
   def test_filter_migrations(self):
-    executor = migration_executor.MigrationExecutor('', '')
+    connection = mock.Mock()
+    executor = migration_executor.MigrationExecutor(connection)
+
     first = migration.Migration('1', None)
     second = migration.Migration('2', '1')
     third = migration.Migration('3', '2')
@@ -127,7 +129,9 @@ class MigrationsTest(unittest.TestCase):
       self.assertEqual(filtered, [first])
 
   def test_filter_migrations_error_on_bad_last_migration(self):
-    executor = migration_executor.MigrationExecutor('', '')
+    connection = mock.Mock()
+    executor = migration_executor.MigrationExecutor(connection)
+
     first = migration.Migration('1', None)
     second = migration.Migration('2', '1')
     third = migration.Migration('3', '2')
@@ -142,7 +146,9 @@ class MigrationsTest(unittest.TestCase):
         executor._filter_migrations(migrations, False, '4')
 
   def test_validate_migrations(self):
-    executor = migration_executor.MigrationExecutor('', '')
+    connection = mock.Mock()
+    executor = migration_executor.MigrationExecutor(connection)
+
     first = migration.Migration('1', None)
     second = migration.Migration('2', '1')
     third = migration.Migration('3', '2')
@@ -158,7 +164,9 @@ class MigrationsTest(unittest.TestCase):
         executor._validate_migrations()
 
   def test_validate_migrations_error_on_unmigrated_after_migrated(self):
-    executor = migration_executor.MigrationExecutor('', '')
+    connection = mock.Mock()
+    executor = migration_executor.MigrationExecutor(connection)
+
     first = migration.Migration('1', None)
     second = migration.Migration('2', '1')
     third = migration.Migration('3', '2')
@@ -176,7 +184,9 @@ class MigrationsTest(unittest.TestCase):
           executor._validate_migrations()
 
   def test_validate_migrations_error_on_unmigrated_first(self):
-    executor = migration_executor.MigrationExecutor('', '')
+    connection = mock.Mock()
+    executor = migration_executor.MigrationExecutor(connection)
+
     first = migration.Migration('2', '1')
     with mock.patch.object(executor, 'migrations') as migrations:
       migrations.return_value = [first]
@@ -191,13 +201,10 @@ class MigrationsTest(unittest.TestCase):
         with self.assertRaises(error.SpannerError):
           executor._validate_migrations()
 
-  @mock.patch('spanner_orm.admin.api.SpannerAdminApi')
-  @mock.patch('spanner_orm.api.SpannerApi')
-  def test_migrate(self, api, admin_api):
-    api.connect = mock.Mock()
-    admin_api.connect = mock.Mock()
+  def test_migrate(self):
+    connection = mock.Mock()
+    executor = migration_executor.MigrationExecutor(connection)
 
-    executor = migration_executor.MigrationExecutor('1', '2', project='3')
     first = migration.Migration('1', None)
     second = migration.Migration('2', '1')
     third = migration.Migration('3', '2')
@@ -207,17 +214,11 @@ class MigrationsTest(unittest.TestCase):
       with mock.patch.object(executor, '_migration_status_map', migrated):
         executor.migrate()
         self.assertEqual(migrated, {'1': True, '2': True, '3': True})
-    api.connect.assert_called_once_with('1', '2', credentials=None, project='3')
-    admin_api.connect.assert_called_once_with(
-        '1', '2', credentials=None, project='3')
 
-  @mock.patch('spanner_orm.admin.api.SpannerAdminApi')
-  @mock.patch('spanner_orm.api.SpannerApi')
-  def test_rollback(self, api, admin_api):
-    api.connect = mock.Mock()
-    admin_api.connect = mock.Mock()
+  def test_rollback(self):
+    connection = mock.Mock()
+    executor = migration_executor.MigrationExecutor(connection)
 
-    executor = migration_executor.MigrationExecutor('1', '2', project='3')
     first = migration.Migration('1', None)
     second = migration.Migration('2', '1')
     third = migration.Migration('3', '2')
@@ -227,9 +228,6 @@ class MigrationsTest(unittest.TestCase):
       with mock.patch.object(executor, '_migration_status_map', migrated):
         executor.rollback('1')
         self.assertEqual(migrated, {'1': False, '2': False, '3': False})
-    api.connect.assert_called_once_with('1', '2', credentials=None, project='3')
-    admin_api.connect.assert_called_once_with(
-        '1', '2', credentials=None, project='3')
 
 
 if __name__ == '__main__':

--- a/spanner_orm/tests/model_api_test.py
+++ b/spanner_orm/tests/model_api_test.py
@@ -22,11 +22,12 @@ from spanner_orm.tests import models
 
 class ModelApiTest(unittest.TestCase):
 
-  @mock.patch('spanner_orm.api.SpannerApi.find')
-  def test_find_calls_api(self, find):
+  @mock.patch('spanner_orm.api.spanner_api')
+  def test_find_calls_api(self, api):
     mock_transaction = mock.Mock()
     models.UnittestModel.find(mock_transaction, string='string', int_=1)
 
+    find = api.return_value.find
     find.assert_called_once()
     (transaction, table, columns, keyset), _ = find.call_args
     self.assertEqual(transaction, mock_transaction)
@@ -34,10 +35,11 @@ class ModelApiTest(unittest.TestCase):
     self.assertEqual(columns, models.UnittestModel.columns)
     self.assertEqual(keyset.keys, [[1, 'string']])
 
-  @mock.patch('spanner_orm.api.SpannerApi.find')
-  def test_find_result(self, find):
+  @mock.patch('spanner_orm.api.spanner_api')
+  def test_find_result(self, api):
     mock_transaction = mock.Mock()
-    find.return_value = [['key', 'value_1', None]]
+
+    api.return_value.find.return_value = [['key', 'value_1', None]]
     result = models.SmallTestModel.find(mock_transaction, key='key')
     if result:
       self.assertEqual(result.key, 'key')
@@ -46,14 +48,15 @@ class ModelApiTest(unittest.TestCase):
     else:
       self.fail('Failed to find result')
 
-  @mock.patch('spanner_orm.api.SpannerApi.find')
-  def test_find_multi_calls_api(self, find):
+  @mock.patch('spanner_orm.api.spanner_api')
+  def test_find_multi_calls_api(self, api):
     mock_transaction = mock.Mock()
     models.UnittestModel.find_multi(mock_transaction, [{
         'string': 'string',
         'int_': 1
     }])
 
+    find = api.return_value.find
     find.assert_called_once()
     (transaction, table, columns, keyset), _ = find.call_args
     self.assertEqual(transaction, mock_transaction)
@@ -61,10 +64,10 @@ class ModelApiTest(unittest.TestCase):
     self.assertEqual(columns, models.UnittestModel.columns)
     self.assertEqual(keyset.keys, [[1, 'string']])
 
-  @mock.patch('spanner_orm.api.SpannerApi.find')
-  def test_find_multi_result(self, find):
+  @mock.patch('spanner_orm.api.spanner_api')
+  def test_find_multi_result(self, api):
     mock_transaction = mock.Mock()
-    find.return_value = [['key', 'value_1', None]]
+    api.return_value.find.return_value = [['key', 'value_1', None]]
     results = models.SmallTestModel.find_multi(mock_transaction, [{
         'key': 'key'
     }])
@@ -73,11 +76,12 @@ class ModelApiTest(unittest.TestCase):
     self.assertEqual(results[0].value_1, 'value_1')
     self.assertIsNone(results[0].value_2)
 
-  @mock.patch('spanner_orm.api.SpannerApi.insert')
-  def test_create_calls_api(self, insert):
+  @mock.patch('spanner_orm.api.spanner_api')
+  def test_create_calls_api(self, api):
     mock_transaction = mock.Mock()
     models.SmallTestModel.create(mock_transaction, key='key', value_1='value')
 
+    insert = api.return_value.insert
     insert.assert_called_once()
     (transaction, table, columns, values), _ = insert.call_args
     self.assertEqual(transaction, mock_transaction)
@@ -97,39 +101,40 @@ class ModelApiTest(unittest.TestCase):
     self.assertEqual(list(columns), ['key', 'value_1', 'value_2'])
     self.assertEqual(list(values), [['key', 'value', None]])
 
-  @mock.patch('spanner_orm.api.SpannerApi.insert')
-  def test_save_batch_inserts(self, insert):
+  @mock.patch('spanner_orm.api.spanner_api')
+  def test_save_batch_inserts(self, api):
     mock_transaction = mock.Mock()
     values = {'key': 'key', 'value_1': 'value'}
     not_persisted = models.SmallTestModel(values)
     models.SmallTestModel.save_batch(mock_transaction, [not_persisted])
-    self.assert_api_called(insert, mock_transaction)
+    self.assert_api_called(api.return_value.insert, mock_transaction)
 
-  @mock.patch('spanner_orm.api.SpannerApi.update')
-  def test_save_batch_updates(self, update):
+  @mock.patch('spanner_orm.api.spanner_api')
+  def test_save_batch_updates(self, api):
     mock_transaction = mock.Mock()
     values = {'key': 'key', 'value_1': 'value'}
     persisted = models.SmallTestModel(values, persisted=True)
     models.SmallTestModel.save_batch(mock_transaction, [persisted])
 
-    self.assert_api_called(update, mock_transaction)
+    self.assert_api_called(api.return_value.update, mock_transaction)
 
-  @mock.patch('spanner_orm.api.SpannerApi.upsert')
-  def test_save_batch_force_write_upserts(self, upsert):
+  @mock.patch('spanner_orm.api.spanner_api')
+  def test_save_batch_force_write_upserts(self, api):
     mock_transaction = mock.Mock()
     values = {'key': 'key', 'value_1': 'value'}
     not_persisted = models.SmallTestModel(values)
     models.SmallTestModel.save_batch(
         mock_transaction, [not_persisted], force_write=True)
-    self.assert_api_called(upsert, mock_transaction)
+    self.assert_api_called(api.return_value.upsert, mock_transaction)
 
-  @mock.patch('spanner_orm.api.SpannerApi.delete')
-  def test_delete_batch_deletes(self, delete):
+  @mock.patch('spanner_orm.api.spanner_api')
+  def test_delete_batch_deletes(self, api):
     mock_transaction = mock.Mock()
     values = {'key': 'key', 'value_1': 'value'}
     model = models.SmallTestModel(values)
     models.SmallTestModel.delete_batch(mock_transaction, [model])
 
+    delete = api.return_value.delete
     delete.assert_called_once()
     (transaction, table, keyset), _ = delete.call_args
     self.assertEqual(transaction, mock_transaction)

--- a/spanner_orm/tests/model_test.py
+++ b/spanner_orm/tests/model_test.py
@@ -181,13 +181,14 @@ class ModelTest(parameterized.TestCase):
     model.save()
     update.assert_not_called()
 
-  @mock.patch('spanner_orm.api.SpannerApi.delete')
-  def test_delete_deletes(self, delete):
+  @mock.patch('spanner_orm.api.spanner_api')
+  def test_delete_deletes(self, api):
     mock_transaction = mock.Mock()
     values = {'key': 'key', 'value_1': 'value_1'}
     model = models.SmallTestModel(values)
     model.delete(mock_transaction)
 
+    delete = api.return_value.delete
     delete.assert_called_once()
     (transaction, table, keyset), _ = delete.call_args
     self.assertEqual(transaction, mock_transaction)

--- a/spanner_orm/tests/query_test.py
+++ b/spanner_orm/tests/query_test.py
@@ -33,21 +33,26 @@ def now():
 
 class QueryTest(parameterized.TestCase):
 
-  @mock.patch('spanner_orm.api.SpannerApi')
+  @mock.patch('spanner_orm.api.spanner_api')
   def test_where(self, spanner_api):
+    spanner_api.return_value.sql_query.return_value = []
+
     models.UnittestModel.where_equal(True, int_=3)
-    (_, sql, parameters, types), _ = spanner_api.sql_query.call_args
+    (_, sql, parameters,
+     types), _ = spanner_api.return_value.sql_query.call_args
 
     expected_sql = 'SELECT .* FROM table WHERE table.int_ = @int_0'
     self.assertRegex(sql, expected_sql)
     self.assertEqual(parameters, {'int_0': 3})
     self.assertEqual(types, {'int_0': field.Integer.grpc_type()})
 
-  @mock.patch('spanner_orm.api.SpannerApi')
+  @mock.patch('spanner_orm.api.spanner_api')
   def test_count(self, spanner_api):
+    spanner_api.return_value.count.return_value = [[0]]
     column, value = 'int_', 3
     models.UnittestModel.count_equal(True, int_=3)
-    (_, sql, parameters, types), _ = spanner_api.sql_query.call_args
+    (_, sql, parameters,
+     types), _ = spanner_api.return_value.sql_query.call_args
 
     column_key = '{}0'.format(column)
     expected_sql = r'SELECT COUNT\(\*\) FROM table WHERE table.{} = @{}'.format(


### PR DESCRIPTION
The code for managing Spanner connections is sort of clunky and I wasn't
able to do things I wanted with it (the primary being you couldn't run
migrations in a process that was also making active queries to the
existing database), so I've split things apart a bit to make that
possible. There's still some more work to allow not using global
connections, but this is enough work for a PR
Note: Depends on #55 and #56 