### PR TITLE
Rename 'schema' to 'fields'

### DIFF
--- a/spanner_orm/admin/update.py
+++ b/spanner_orm/admin/update.py
@@ -53,7 +53,7 @@ class CreateTable(SchemaUpdate):
   def ddl(self) -> str:
     fields = [
         '{} {}'.format(name, field.ddl())
-        for name, field in self._model.schema.items()
+        for name, field in self._model.fields.items()
     ]
     index_ddl = 'PRIMARY KEY ({})'.format(', '.join(self._model.primary_keys))
     statement = 'CREATE TABLE {} ({}) {}'.format(self._model.table,
@@ -98,7 +98,7 @@ class CreateTable(SchemaUpdate):
           self._model.table))
 
     for key in self._model.primary_keys:
-      if key not in self._model.schema:
+      if key not in self._model.fields:
         raise error.SpannerError(
             'Table {} column {} in primary key but not in schema'.format(
                 self._model.table, key))
@@ -178,7 +178,7 @@ class DropColumn(SchemaUpdate):
     if not model_:
       raise error.SpannerError('Table {} does not exist'.format(self._table))
 
-    if self._column not in model_.schema:
+    if self._column not in model_.fields:
       raise error.SpannerError('Column {} does not exist on {}'.format(
           self._column, self._table))
 
@@ -210,7 +210,7 @@ class AlterColumn(SchemaUpdate):
     if not model_:
       raise error.SpannerError('Table {} does not exist'.format(self._table))
 
-    if self._column not in model_.schema:
+    if self._column not in model_.fields:
       raise error.SpannerError('Column {} does not exist on {}'.format(
           self._column, self._table))
 
@@ -218,7 +218,7 @@ class AlterColumn(SchemaUpdate):
       raise error.SpannerError('Column {} is a primary key on {}'.format(
           self._column, self._table))
 
-    old_field = model_.schema[self._column]
+    old_field = model_.fields[self._column]
     # Validate that the only alteration is to change column nullability
     if self._field.field_type() != old_field.field_type():
       raise error.SpannerError('Column {} is changing type'.format(

--- a/spanner_orm/condition.py
+++ b/spanner_orm/condition.py
@@ -117,10 +117,10 @@ class ColumnsEqualCondition(Condition):
     return {}
 
   def _validate(self, model_class: Type[Any]) -> None:
-    assert self.column in model_class.schema
-    origin = model_class.schema[self.column]
-    assert self.destination_column in self.destination_model_class.schema
-    dest = self.destination_model_class.schema[self.destination_column]
+    assert self.column in model_class.fields
+    origin = model_class.fields[self.column]
+    assert self.destination_column in self.destination_model_class.fields
+    dest = self.destination_model_class.fields[self.destination_column]
 
     assert (origin.field_type() == dest.field_type() and
             origin.nullable() == dest.nullable())
@@ -377,7 +377,7 @@ class OrderByCondition(Condition):
     for (column, _) in self.orderings:
       if isinstance(column, field.Field):
         column = column.name
-      assert column in model_class.schema
+      assert column in model_class.fields
 
 
 class ComparisonCondition(Condition):
@@ -414,14 +414,14 @@ class ComparisonCondition(Condition):
         column_key=self._column_key)
 
   def _types(self) -> type_pb2.Type:
-    return {self._column_key: self.model_class.schema[self.column].grpc_type()}
+    return {self._column_key: self.model_class.fields[self.column].grpc_type()}
 
   def _validate(self, model_class: Type[Any]) -> None:
-    assert self.column in model_class.schema
+    assert self.column in model_class.fields
     if self.field:
-      assert self.field == model_class.schema[self.column]
+      assert self.field == model_class.fields[self.column]
     assert self.value is not None
-    model_class.schema[self.column].validate(self.value)
+    model_class.fields[self.column].validate(self.value)
 
 
 class ListComparisonCondition(ComparisonCondition):
@@ -435,17 +435,17 @@ class ListComparisonCondition(ComparisonCondition):
         column_key=self._column_key)
 
   def _types(self) -> type_pb2.Type:
-    grpc_type = self.model_class.schema[self.column].grpc_type()
+    grpc_type = self.model_class.fields[self.column].grpc_type()
     list_type = type_pb2.Type(code=type_pb2.ARRAY, array_element_type=grpc_type)
     return {self._column_key: list_type}
 
   def _validate(self, model_class: Type[Any]) -> None:
     assert isinstance(self.value, list)
-    assert self.column in model_class.schema
+    assert self.column in model_class.fields
     if self.field:
-      assert self.field == model_class.schema[self.column]
+      assert self.field == model_class.fields[self.column]
     for value in self.value:
-      model_class.schema[self.column].validate(value)
+      model_class.fields[self.column].validate(value)
 
 
 class NullableComparisonCondition(ComparisonCondition):
@@ -478,10 +478,10 @@ class NullableComparisonCondition(ComparisonCondition):
     return super()._types()
 
   def _validate(self, model_class: Type[Any]) -> None:
-    assert self.column in model_class.schema
+    assert self.column in model_class.fields
     if self.field:
-      assert self.field == model_class.schema[self.column]
-    model_class.schema[self.column].validate(self.value)
+      assert self.field == model_class.fields[self.column]
+    model_class.fields[self.column].validate(self.value)
 
 
 class EqualityCondition(NullableComparisonCondition):

--- a/spanner_orm/model.py
+++ b/spanner_orm/model.py
@@ -77,8 +77,8 @@ class ModelMetaclass(type):
       name: str) -> Union[field.Field, relationship.Relationship, index.Index]:
     # Unclear why pylint doesn't like this
     # pylint: disable=unsupported-membership-test
-    if name in cls.schema:
-      return cls.schema[name]
+    if name in cls.fields:
+      return cls.fields[name]
     elif name in cls.relations:
       return cls.relations[name]
     elif name in cls.indexes:
@@ -90,7 +90,7 @@ class ModelMetaclass(type):
   def column_prefix(cls) -> str:
     return cls.table.split('.')[-1]
 
-  # Table schema class methods
+  # Table fields class methods
   @property
   def columns(cls) -> List[str]:
     return cls.meta.columns
@@ -114,7 +114,7 @@ class ModelMetaclass(type):
     return cls.meta.relations
 
   @property
-  def schema(cls) -> Dict[str, field.Field]:
+  def fields(cls) -> Dict[str, field.Field]:
     return cls.meta.fields
 
   @property
@@ -123,7 +123,7 @@ class ModelMetaclass(type):
 
   def validate_value(cls, field_name, value, error_type=error.SpannerError):
     try:
-      cls.schema[field_name].validate(value)
+      cls.fields[field_name].validate(value)
     except AssertionError as ex:
       raise error_type(*ex.args)
 
@@ -369,7 +369,7 @@ class Model(ModelApi):
 
   @property
   def _fields(self) -> Dict[str, field.Field]:
-    return self._metaclass.schema
+    return self._metaclass.fields
 
   @property
   def _primary_keys(self) -> List[str]:

--- a/spanner_orm/relationship.py
+++ b/spanner_orm/relationship.py
@@ -80,11 +80,11 @@ class Relationship(object):
     """Validates the dictionary of constraints and turns it into Conditions."""
     constraints = []
     for origin_column, destination_column in self._constraints.items():
-      if origin_column not in self.origin.schema:
+      if origin_column not in self.origin.fields:
         raise error.SpannerError(
             'Origin column must be present in origin model')
 
-      if destination_column not in self.destination.schema:
+      if destination_column not in self.destination.fields:
         raise error.SpannerError(
             'Destination column must be present in destination model')
 

--- a/spanner_orm/tests/admin_test.py
+++ b/spanner_orm/tests/admin_test.py
@@ -40,7 +40,7 @@ class AdminTest(unittest.TestCase):
 
   def make_test_columns(self, model):
     columns, iteration = [], 1
-    for row in model.schema.values():
+    for row in model.fields.values():
       columns.append({
           'table_catalog': '',
           'table_schema': '',
@@ -109,10 +109,10 @@ class AdminTest(unittest.TestCase):
     self.assertEqual(meta.table, model.table)
     self.assertEqual(meta.columns, model.columns)
     for row in model.columns:
-      self.assertEqual(meta.schema[row].field_type(),
-                       model.schema[row].field_type())
-      self.assertEqual(meta.schema[row].nullable(),
-                       model.schema[row].nullable())
+      self.assertEqual(meta.fields[row].field_type(),
+                       model.fields[row].field_type())
+      self.assertEqual(meta.fields[row].nullable(),
+                       model.fields[row].nullable())
     self.assertEqual(meta.primary_keys, model.primary_keys)
     self.assertEqual(
         getattr(meta, index.Index.PRIMARY_INDEX).columns, model.primary_keys)


### PR DESCRIPTION
This has been bugging me for a while. Since we switched to having
table metadata in a separate class, using 'schema' to refer to the list
of fields was no longer accurate, so I've renamed those places to
'fields'