### PR TITLE
Move the transaction lambda helpers out of SpannerApi

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ number of failures happen.  Make sure that there are no side effects that could
 cause issues if called multiple times. Exceptions thrown out of the called
 method will abort the transaction.
 
-Other write methods are exposed on ```spanner_orm.spanner_api()``` for more
-complex use cases, but you will have to do more work in order to use those
+Other helper methods exist for more complex use cases (```create```, ```update```,
+```upsert```, and others), but you will have to do more work in order to use those
 correctly. See the documentation on those methods for more information.
 
 ## Migrations

--- a/spanner_orm/__init__.py
+++ b/spanner_orm/__init__.py
@@ -23,9 +23,10 @@ from spanner_orm import field
 from spanner_orm import index
 from spanner_orm import model
 from spanner_orm import relationship
+from spanner_orm import table_apis
 from spanner_orm.admin import api as admin_api
 from spanner_orm.admin import migration_executor
-from spanner_orm.admin import update
+from spanner_orm.admin import update as update_module
 
 # add NullHandler to root-module logger so that individual modules
 # won't have to.
@@ -46,6 +47,13 @@ connect_admin = admin_api.connect
 from_admin_connection = admin_api.from_connection
 hangup_admin = admin_api.hangup
 spanner_admin_api = admin_api.spanner_admin_api
+
+find = table_apis.find
+sql_query = table_apis.sql_query
+delete = table_apis.delete
+insert = table_apis.insert
+update = table_apis.update
+upsert = table_apis.upsert
 
 Model = model.Model
 
@@ -78,14 +86,14 @@ ORDER_DESC = condition.OrderType.DESC
 transactional_read = decorator.transactional_read
 transactional_write = decorator.transactional_write
 
-CreateTable = update.CreateTable
-DropTable = update.DropTable
-AddColumn = update.AddColumn
-DropColumn = update.DropColumn
-AlterColumn = update.AlterColumn
-CreateIndex = update.CreateIndex
-DropIndex = update.DropIndex
-NoUpdate = update.NoUpdate
-model_creation_ddl = update.model_creation_ddl
+CreateTable = update_module.CreateTable
+DropTable = update_module.DropTable
+AddColumn = update_module.AddColumn
+DropColumn = update_module.DropColumn
+AlterColumn = update_module.AlterColumn
+CreateIndex = update_module.CreateIndex
+DropIndex = update_module.DropIndex
+NoUpdate = update_module.NoUpdate
+model_creation_ddl = update_module.model_creation_ddl
 
 MigrationExecutor = migration_executor.MigrationExecutor

--- a/spanner_orm/table_apis.py
+++ b/spanner_orm/table_apis.py
@@ -1,0 +1,157 @@
+# python3
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Table-level API lambdas for Spanner transactions."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Iterable, List
+
+from google.cloud import spanner
+from google.cloud.spanner_v1 import transaction as spanner_transaction
+from google.cloud.spanner_v1.proto import type_pb2
+
+_logger = logging.getLogger(__name__)
+
+
+# Read methods
+def find(transaction: spanner_transaction.Transaction, table_name: str,
+         columns: Iterable[str], keyset: spanner.KeySet) -> List[Iterable[Any]]:
+  """Retrieves rows from the given table based on the provided KeySet.
+
+  Args:
+    transaction: The Spanner transaction to execute the request on
+    table_name: The Spanner table being queried
+    columns: Which columns to retrieve from the Spanner table
+    keyset: Contains a list of primary keys that indicates which rows to
+      retrieve from the Spanner table
+
+  Returns:
+    A list of lists. Each sublist is the set of `columns` requested from
+    a row in the Spanner table whose primary key matches one of the
+    primary keys in the `keyset`. The order of the values in the sublist
+    matches the order of the columns from the `columns` parameter.
+  """
+  _logger.debug('Find table=%s columns=%s keys=%s', table_name, columns,
+                keyset.keys)
+  stream_results = transaction.read(
+      table=table_name, columns=columns, keyset=keyset)
+  return list(stream_results)
+
+
+def sql_query(transaction: spanner_transaction.Transaction, query: str,
+              parameters: Dict[str, Any],
+              parameter_types: Dict[str, type_pb2.Type]) -> List[Iterable[Any]]:
+  """Executes a given SQL query against the Spanner database.
+
+  This isn't technically read-only, but it's necessary to implement the read-
+  only features of the ORM
+
+  Args:
+    transaction: The Spanner transaction to execute the request on
+    query: The SQL query to run
+    parameters: A mapping from the names of the parameters used in the SQL query
+      to the value to be substituted in for that parameter
+    parameter_types: A mapping from the names of the parameters used in the SQL
+      query to the type of the value being substituted in for that parameter
+
+  Returns:
+    A list of lists. Each sublist is a result row from the SQL query. For
+    SELECT queries, the order of values in the sublist matches the order
+    of the columns requested from the SELECT clause of the query.
+  """
+  _logger.debug('Executing SQL:\n%s\n%s\n%s', query, parameters,
+                parameter_types)
+  stream_results = transaction.execute_sql(
+      query, params=parameters, param_types=parameter_types)
+  return list(stream_results)
+
+
+def delete(transaction: spanner_transaction.Transaction, table_name: str,
+           keyset: spanner.KeySet) -> None:
+  """Deletes rows from the given table based on the provided KeySet.
+
+  Args:
+    transaction: The Spanner transaction to execute the request on
+    table_name: The Spanner table being modified
+    keyset: Contains a list of primary keys that indicates which rows to delete
+      from the Spanner table
+  """
+
+  _logger.debug('Delete table=%s keys=%s', table_name, keyset.keys)
+  transaction.delete(table=table_name, keyset=keyset)
+
+
+def insert(transaction: spanner_transaction.Transaction, table_name: str,
+           columns: Iterable[str], values: Iterable[Iterable[Any]]) -> None:
+  """Adds rows to the given table based on the provided values.
+
+  All non-nullable columns must be specified. Note that if a row is specified
+  for which the primary key already exists in the table, an exception will
+  be thrown and the insert will be aborted.
+
+  Args:
+    transaction: The Spanner transaction to execute the request on
+    table_name: The Spanner table being modified
+    columns: Which columns to write on the Spanner table
+    values: A list of rows to write to the table. The order of the values in
+      each sublist must match the order of the columns specified in the
+      `columns` parameter.
+  """
+  _logger.debug('Insert table=%s columns=%s values=%s', table_name, columns,
+                values)
+  transaction.insert(table=table_name, columns=columns, values=values)
+
+
+def update(transaction: spanner_transaction.Transaction, table_name: str,
+           columns: Iterable[str], values: Iterable[Iterable[Any]]) -> None:
+  """Updates rows in the given table based on the provided values.
+
+  Note that if a row is specified for which the primary key does not
+  exist in the table, an exception will be thrown and the update
+  will be aborted.
+
+  Args:
+    transaction: The Spanner transaction to execute the request on
+    table_name: The Spanner table being modified
+    columns: Which columns to write on the Spanner table
+    values: A list of rows to write to the table. The order of the values in
+      each sublist must match the order of the columns specified in the
+      `columns` parameter.
+  """
+  _logger.debug('Update table=%s columns=%s values=%s', table_name, columns,
+                values)
+  transaction.update(table=table_name, columns=columns, values=values)
+
+
+def upsert(transaction: spanner_transaction.Transaction, table_name: str,
+           columns: Iterable[str], values: Iterable[Iterable[Any]]) -> None:
+  """Inserts or updates rows in the given table based on the provided values.
+
+  All non-nullable columns must be specified, similarly to the insert method.
+  The presence or absence of data in the table will not cause an exception
+  to be thrown, unlike insert or update.
+
+  Args:
+    transaction: The Spanner transaction to execute the request on
+    table_name: The Spanner table being modified
+    columns: Which columns to write on the Spanner table
+    values: A list of rows to write to the table. The order of the values in
+      each sublist must match the order of the columns specified in the
+      `columns` parameter.
+  """
+  _logger.debug('Upsert table=%s columns=%s values=%s', table_name, columns,
+                values)
+  transaction.insert_or_update(table=table_name, columns=columns, values=values)

--- a/spanner_orm/tests/decorator_test.py
+++ b/spanner_orm/tests/decorator_test.py
@@ -48,8 +48,7 @@ class DecoratorTest(parameterized.TestCase):
 
   @parameterized.parameters(decorator.transactional_read,
                             decorator.transactional_write)
-  @mock.patch('spanner_orm.api.spanner_api')
-  def test_transactional_uses_given_transaction(self, decorator_in_test, _):
+  def test_transactional_uses_given_transaction(self, decorator_in_test):
     mock_tx = mock.Mock()
 
     @decorator_in_test

--- a/spanner_orm/tests/model_test.py
+++ b/spanner_orm/tests/model_test.py
@@ -181,14 +181,13 @@ class ModelTest(parameterized.TestCase):
     model.save()
     update.assert_not_called()
 
-  @mock.patch('spanner_orm.api.spanner_api')
-  def test_delete_deletes(self, api):
+  @mock.patch('spanner_orm.table_apis.delete')
+  def test_delete_deletes(self, delete):
     mock_transaction = mock.Mock()
     values = {'key': 'key', 'value_1': 'value_1'}
     model = models.SmallTestModel(values)
     model.delete(mock_transaction)
 
-    delete = api.return_value.delete
     delete.assert_called_once()
     (transaction, table, keyset), _ = delete.call_args
     self.assertEqual(transaction, mock_transaction)

--- a/spanner_orm/tests/query_test.py
+++ b/spanner_orm/tests/query_test.py
@@ -33,26 +33,24 @@ def now():
 
 class QueryTest(parameterized.TestCase):
 
-  @mock.patch('spanner_orm.api.spanner_api')
-  def test_where(self, spanner_api):
-    spanner_api.return_value.sql_query.return_value = []
+  @mock.patch('spanner_orm.table_apis.sql_query')
+  def test_where(self, sql_query):
+    sql_query.return_value = []
 
     models.UnittestModel.where_equal(True, int_=3)
-    (_, sql, parameters,
-     types), _ = spanner_api.return_value.sql_query.call_args
+    (_, sql, parameters, types), _ = sql_query.call_args
 
     expected_sql = 'SELECT .* FROM table WHERE table.int_ = @int_0'
     self.assertRegex(sql, expected_sql)
     self.assertEqual(parameters, {'int_0': 3})
     self.assertEqual(types, {'int_0': field.Integer.grpc_type()})
 
-  @mock.patch('spanner_orm.api.spanner_api')
-  def test_count(self, spanner_api):
-    spanner_api.return_value.count.return_value = [[0]]
+  @mock.patch('spanner_orm.table_apis.sql_query')
+  def test_count(self, sql_query):
+    sql_query.return_value = [[0]]
     column, value = 'int_', 3
     models.UnittestModel.count_equal(True, int_=3)
-    (_, sql, parameters,
-     types), _ = spanner_api.return_value.sql_query.call_args
+    (_, sql, parameters, types), _ = sql_query.call_args
 
     column_key = '{}0'.format(column)
     expected_sql = r'SELECT COUNT\(\*\) FROM table WHERE table.{} = @{}'.format(


### PR DESCRIPTION
While updating a project to use the newest version of spanner-orm, I
found a couple issues:
- The decorators didn't work because api.spanner_api() was being
evaluated too early. Put it inside a generator to delay evaluating until
call time.
- Getting to the helpers that just call methods on the transaction was
pretty unwieldy, as you had to go through api.spanner_api(), which added
unneeded extra layers of mocking in unit tests. Moved all of these out
to top-level functions in spanner_orm.table_apis and added exports to
__init__.py