### PR TITLE
All processing uses result_to_model

### DIFF
--- a/spanner_orm/model.py
+++ b/spanner_orm/model.py
@@ -307,7 +307,11 @@ class ModelApi(metaclass=ModelMetaclass):
   def _results_to_models(cls,
                          results: Iterable[Iterable[Any]]) -> List[ModelObject]:
     items = [dict(zip(cls.columns, result)) for result in results]
-    return [cls(item, persisted=True) for item in items]
+    return [cls.result_to_model(item) for item in items]
+
+  @classmethod
+  def result_to_model(cls, values):
+    return cls(values, persisted=True)
 
   @classmethod
   def _execute_read(cls, db_api: Callable[..., CallableReturn],

--- a/spanner_orm/query.py
+++ b/spanner_orm/query.py
@@ -204,7 +204,7 @@ class SelectQuery(SpannerQuery):
         values[join.relation_name] = models[0] if models else None
       else:
         values[join.relation_name] = models
-    return self._model(values, persisted=True)
+    return self._model.result_to_model(values)
 
 
 class _SelectSubQuery(SelectQuery):


### PR DESCRIPTION
This causes all row processing to go through `model.result_to_model`.  It feels a little weird because if you didn't know about the overriding aspect of it, this method would seem fairly redundant.  Should we just add a comment saying as much, or should we move the logic from `process_row` into here (which feels off because that feels like it belongs in `query.py`), or something else entirely?