### PR TITLE
Fix some type annotations that diverged.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ admin_api = spanner_orm.connect_admin(
   'instance_name',
   'database_name',
   create_ddl=spanner_orm.model_creation_ddl(TestModel))
-admin_api.create()
+admin_api.create_database()
 ```
 
 If the database already exists, we can execute a Migration where the upgrade

--- a/spanner_orm/__init__.py
+++ b/spanner_orm/__init__.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Sets up shortcuts for imports from the library."""
 import logging
 
@@ -97,3 +98,8 @@ NoUpdate = update_module.NoUpdate
 model_creation_ddl = update_module.model_creation_ddl
 
 MigrationExecutor = migration_executor.MigrationExecutor
+
+try:
+  __import__('pkg_resources').declare_namespace('spanner_orm')
+except ImportError:
+  __path__ = __import__('pkgutil').extend_path(__path__, 'spanner_orm')

--- a/spanner_orm/admin/api.py
+++ b/spanner_orm/admin/api.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Class that handles API calls to Spanner that deal with table metadata."""
 
-from __future__ import annotations
-
 from typing import Iterable, Optional
 from spanner_orm import api
 from spanner_orm import error
@@ -23,6 +21,7 @@ from spanner_orm import error
 from google.auth import credentials as auth_credentials
 from google.cloud import spanner
 from google.cloud.spanner_v1 import database as spanner_database
+from google.cloud.spanner_v1.pool import AbstractSessionPool
 
 
 class SpannerAdminApi(api.SpannerReadApi, api.SpannerWriteApi):
@@ -32,7 +31,7 @@ class SpannerAdminApi(api.SpannerReadApi, api.SpannerWriteApi):
     self._spanner_connection = connection
 
   @property
-  def _connection(self) -> spanner_database.SpannerDatabase:
+  def _connection(self) -> spanner_database.Database:
     return self._spanner_connection.database
 
   def create_database(self) -> None:
@@ -54,7 +53,7 @@ def connect(instance: str,
             database: str,
             project: Optional[str] = None,
             credentials: Optional[auth_credentials.Credentials] = None,
-            pool: Optional[spanner.Pool] = None,
+            pool: Optional[AbstractSessionPool] = None,
             create_ddl: Optional[Iterable[str]] = None) -> SpannerAdminApi:
   """Connects the global Spanner admin API to a Spanner database."""
   connection = api.SpannerConnection(

--- a/spanner_orm/admin/api.py
+++ b/spanner_orm/admin/api.py
@@ -19,9 +19,8 @@ from spanner_orm import api
 from spanner_orm import error
 
 from google.auth import credentials as auth_credentials
-from google.cloud import spanner
 from google.cloud.spanner_v1 import database as spanner_database
-from google.cloud.spanner_v1.pool import AbstractSessionPool
+from google.cloud.spanner_v1 import pool as spanner_pool
 
 
 class SpannerAdminApi(api.SpannerReadApi, api.SpannerWriteApi):
@@ -53,7 +52,7 @@ def connect(instance: str,
             database: str,
             project: Optional[str] = None,
             credentials: Optional[auth_credentials.Credentials] = None,
-            pool: Optional[AbstractSessionPool] = None,
+            pool: Optional[spanner_pool.AbstractSessionPool] = None,
             create_ddl: Optional[Iterable[str]] = None) -> SpannerAdminApi:
   """Connects the global Spanner admin API to a Spanner database."""
   connection = api.SpannerConnection(

--- a/spanner_orm/admin/column.py
+++ b/spanner_orm/admin/column.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Model for interacting with Spanner column schema table."""
 
-from __future__ import annotations
-
 from typing import Type
 
 from spanner_orm import error

--- a/spanner_orm/admin/index.py
+++ b/spanner_orm/admin/index.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Model for interacting with Spanner index schema table."""
 
-from __future__ import annotations
-
 from spanner_orm import field
 from spanner_orm.admin import schema
 

--- a/spanner_orm/admin/index_column.py
+++ b/spanner_orm/admin/index_column.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Model for interacting with Spanner index column schema table."""
 
-from __future__ import annotations
-
 from spanner_orm import field
 from spanner_orm.admin import schema
 

--- a/spanner_orm/admin/metadata.py
+++ b/spanner_orm/admin/metadata.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Retrieves table metadata from Spanner."""
 
-from __future__ import annotations
-
 import collections
 from typing import Any, Dict, Optional, Type
 

--- a/spanner_orm/admin/migration.py
+++ b/spanner_orm/admin/migration.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Holds information about a specific migration."""
 
-from __future__ import annotations
-
 from typing import Callable, Optional
 
 from spanner_orm.admin import update

--- a/spanner_orm/admin/migration_executor.py
+++ b/spanner_orm/admin/migration_executor.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Handles execution of migrations."""
 
-from __future__ import annotations
-
 import datetime
 import logging
 from typing import Iterable, List, Dict, Optional

--- a/spanner_orm/admin/migration_manager.py
+++ b/spanner_orm/admin/migration_manager.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Handles reading and writing of migration files."""
 
-from __future__ import annotations
-
 import datetime
 import importlib
 import os
@@ -91,7 +89,7 @@ class MigrationManager:
     migrations = []
     for filename in os.listdir(self.basedir):
       _, ext = os.path.splitext(filename)
-      if ext == '.py':
+      if ext == '.py' and filename != '__init__.py':
         migrations.append(self._migration_from_file(filename))
     return migrations
 

--- a/spanner_orm/admin/migration_status.py
+++ b/spanner_orm/admin/migration_status.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Indicates whether a migration has been applied to the current database."""
 
-from __future__ import annotations
-
 from spanner_orm import field
 from spanner_orm import model
 from spanner_orm.admin import api

--- a/spanner_orm/admin/schema.py
+++ b/spanner_orm/admin/schema.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Base model for schemas."""
 
-from __future__ import annotations
-
 from typing import NoReturn
 
 from spanner_orm import error

--- a/spanner_orm/admin/scripts.py
+++ b/spanner_orm/admin/scripts.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Entry point for spanner_orm scripts."""
 
-from __future__ import annotations
-
 import argparse
 from typing import Any
 

--- a/spanner_orm/admin/table.py
+++ b/spanner_orm/admin/table.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Model for interacting with Spanner column schema table."""
 
-from __future__ import annotations
-
 from spanner_orm import field
 from spanner_orm.admin import schema
 

--- a/spanner_orm/admin/update.py
+++ b/spanner_orm/admin/update.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Used with SpannerAdminApi to manage Spanner schema updates."""
 
-from __future__ import annotations
-
 import abc
 from typing import Iterable, List, Optional, Type
 

--- a/spanner_orm/api.py
+++ b/spanner_orm/api.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# pytype: skip-file
 """Class that handles API calls to Spanner."""
 
 import abc
@@ -23,7 +22,7 @@ from spanner_orm import error
 from google.auth import credentials as auth_credentials
 from google.cloud import spanner
 from google.cloud.spanner_v1 import database as spanner_database
-from google.cloud.spanner_v1.pool import AbstractSessionPool
+from google.cloud.spanner_v1 import pool as spanner_pool
 
 CallableReturn = TypeVar('CallableReturn')
 
@@ -92,7 +91,7 @@ class SpannerConnection:
                database: str,
                project: Optional[str] = None,
                credentials: Optional[auth_credentials.Credentials] = None,
-               pool: Optional[AbstractSessionPool] = None,
+               pool: Optional[spanner_pool.AbstractSessionPool] = None,
                create_ddl: Optional[Iterable[str]] = None):
     """Connects to the specified Spanner database."""
     client = spanner.Client(project=project, credentials=credentials)

--- a/spanner_orm/api.py
+++ b/spanner_orm/api.py
@@ -12,9 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# pytype: skip-file
 """Class that handles API calls to Spanner."""
-
-from __future__ import annotations
 
 import abc
 from typing import Any, Callable, Iterable, Optional, TypeVar
@@ -24,6 +23,7 @@ from spanner_orm import error
 from google.auth import credentials as auth_credentials
 from google.cloud import spanner
 from google.cloud.spanner_v1 import database as spanner_database
+from google.cloud.spanner_v1.pool import AbstractSessionPool
 
 CallableReturn = TypeVar('CallableReturn')
 
@@ -60,7 +60,7 @@ class SpannerWriteApi(abc.ABC):
 
   @property
   @abc.abstractmethod
-  def _connection(self) -> spanner_database.SpannerDatabase:
+  def _connection(self) -> spanner_database.Database:
     raise NotImplementedError
 
   def run_write(self, method: Callable[..., CallableReturn], *args: Any,
@@ -92,7 +92,7 @@ class SpannerConnection:
                database: str,
                project: Optional[str] = None,
                credentials: Optional[auth_credentials.Credentials] = None,
-               pool: Optional[spanner.Pool] = None,
+               pool: Optional[AbstractSessionPool] = None,
                create_ddl: Optional[Iterable[str]] = None):
     """Connects to the specified Spanner database."""
     client = spanner.Client(project=project, credentials=credentials)
@@ -119,7 +119,7 @@ def connect(instance: str,
             database: str,
             project: Optional[str] = None,
             credentials: Optional[auth_credentials.Credentials] = None,
-            pool: Optional[spanner.Pool] = None) -> SpannerApi:
+            pool: Optional[AbstractSessionPool] = None) -> SpannerApi:
   """Connects to the Spanner database and sets the global spanner_api."""
   connection = SpannerConnection(
       instance, database, project=project, credentials=credentials, pool=pool)

--- a/spanner_orm/api.py
+++ b/spanner_orm/api.py
@@ -118,7 +118,8 @@ def connect(instance: str,
             database: str,
             project: Optional[str] = None,
             credentials: Optional[auth_credentials.Credentials] = None,
-            pool: Optional[AbstractSessionPool] = None) -> SpannerApi:
+            pool: Optional[spanner_pool.AbstractSessionPool] = None
+           ) -> SpannerApi:
   """Connects to the Spanner database and sets the global spanner_api."""
   connection = SpannerConnection(
       instance, database, project=project, credentials=credentials, pool=pool)

--- a/spanner_orm/condition.py
+++ b/spanner_orm/condition.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Used with Model#where and Model#count to help create Spanner queries."""
 
-from __future__ import annotations
-
 import abc
 import enum
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union

--- a/spanner_orm/decorator.py
+++ b/spanner_orm/decorator.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Transaction decorators."""
 
-from __future__ import annotations
-
 from typing import Callable, TypeVar
 
 from spanner_orm import api

--- a/spanner_orm/field.py
+++ b/spanner_orm/field.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Helper to deal with field types in Spanner interactions."""
 
-from __future__ import annotations
-
 import abc
 import datetime
 from typing import Any, Type
@@ -23,6 +21,25 @@ from typing import Any, Type
 from spanner_orm import error
 
 from google.cloud.spanner_v1.proto import type_pb2
+
+
+class FieldType(abc.ABC):
+  """Base class for column types for Spanner interactions."""
+
+  @staticmethod
+  @abc.abstractmethod
+  def ddl() -> str:
+    raise NotImplementedError
+
+  @staticmethod
+  @abc.abstractmethod
+  def grpc_type() -> type_pb2.Type:
+    raise NotImplementedError
+
+  @staticmethod
+  @abc.abstractmethod
+  def validate_type(value: Any) -> None:
+    raise NotImplementedError
 
 
 class Field(object):
@@ -60,25 +77,6 @@ class Field(object):
         raise error.ValidationError('None set for non-nullable field')
     else:
       self._type.validate_type(value)
-
-
-class FieldType(abc.ABC):
-  """Base class for column types for Spanner interactions."""
-
-  @staticmethod
-  @abc.abstractmethod
-  def ddl() -> str:
-    raise NotImplementedError
-
-  @staticmethod
-  @abc.abstractmethod
-  def grpc_type() -> type_pb2.Type:
-    raise NotImplementedError
-
-  @staticmethod
-  @abc.abstractmethod
-  def validate_type(value: Any) -> None:
-    raise NotImplementedError
 
 
 class Boolean(FieldType):

--- a/spanner_orm/index.py
+++ b/spanner_orm/index.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Represents an index on a Model."""
 
-from __future__ import annotations
-
 from typing import List, Optional
 
 from spanner_orm import error

--- a/spanner_orm/metadata.py
+++ b/spanner_orm/metadata.py
@@ -28,8 +28,6 @@
 # limitations under the License.
 """Hold information about a Model extracted from the class attributes."""
 
-from __future__ import annotations
-
 from typing import Any, Dict, Type, Optional
 
 from spanner_orm import error
@@ -86,7 +84,7 @@ class ModelMetadata(object):
     registry.model_registry().register(self.model_class)
     self._finalized = True
 
-  def add_metadata(self, metadata: ModelMetadata) -> None:
+  def add_metadata(self, metadata: 'ModelMetadata') -> None:
     self.table = metadata.table or self.table
     self.fields.update(metadata.fields)
     self.relations.update(metadata.relations)

--- a/spanner_orm/model.py
+++ b/spanner_orm/model.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Holds table-specific information to make querying spanner eaiser."""
 
-from __future__ import annotations
-
 import collections
 import copy
 from typing import Any, Callable, Dict, Iterable, List, Optional, Type, TypeVar, Union
@@ -101,7 +99,7 @@ class ModelMetaclass(type):
     return cls.meta.indexes
 
   @property
-  def interleaved(cls) -> Optional[Type[Model]]:
+  def interleaved(cls) -> Optional[Type['Model']]:
     if cls.meta.interleaved:
       return registry.model_registry().get(cls.meta.interleaved)
     return None
@@ -151,7 +149,7 @@ class ModelApi(metaclass=ModelMetaclass):
   def all(
       cls,
       transaction: Optional[spanner_transaction.Transaction] = None
-  ) -> List[ModelObject]:
+  ) -> List['ModelObject']:
     """Returns all objects of this type stored in Spanner.
 
     Note: this method should only be called on subclasses of Model that have
@@ -219,7 +217,7 @@ class ModelApi(metaclass=ModelMetaclass):
   @classmethod
   def find(cls,
            transaction: Optional[spanner_transaction.Transaction] = None,
-           **keys: Any) -> Optional[ModelObject]:
+           **keys: Any) -> Optional['ModelObject']:
     """Retrieves an object from Spanner based on the provided key.
 
     Args:
@@ -237,7 +235,7 @@ class ModelApi(metaclass=ModelMetaclass):
 
   @classmethod
   def find_multi(cls, transaction: Optional[spanner_transaction.Transaction],
-                 keys: Iterable[Dict[str, Any]]) -> List[ModelObject]:
+                 keys: Iterable[Dict[str, Any]]) -> List['ModelObject']:
     """Retrieves objects from Spanner based on the provided keys.
 
     Args:
@@ -262,7 +260,7 @@ class ModelApi(metaclass=ModelMetaclass):
 
   @classmethod
   def where(cls, transaction: Optional[spanner_transaction.Transaction],
-            *conditions: condition.Condition) -> List[ModelObject]:
+            *conditions: condition.Condition) -> List['ModelObject']:
     """Retrieves objects from Spanner based on the provided conditions.
 
     Args:
@@ -283,7 +281,7 @@ class ModelApi(metaclass=ModelMetaclass):
   @classmethod
   def where_equal(cls,
                   transaction: Optional[spanner_transaction.Transaction] = None,
-                  **constraints: Any) -> List[ModelObject]:
+                  **constraints: Any) -> List['ModelObject']:
     """Retrieves objects from Spanner based on the provided constraints.
 
     Args:
@@ -307,7 +305,7 @@ class ModelApi(metaclass=ModelMetaclass):
 
   @classmethod
   def _results_to_models(cls,
-                         results: Iterable[Iterable[Any]]) -> List[ModelObject]:
+                         results: Iterable[Iterable[Any]]) -> List['ModelObject']:
     items = [dict(zip(cls.columns, result)) for result in results]
     return [cls(item, persisted=True) for item in items]
 
@@ -347,7 +345,7 @@ class ModelApi(metaclass=ModelMetaclass):
 
   @classmethod
   def delete_batch(cls, transaction: Optional[spanner_transaction.Transaction],
-                   models: List[ModelObject]) -> None:
+                   models: List['ModelObject']) -> None:
     """Deletes rows from Spanner based on the provided models' primary keys.
 
     Args:
@@ -370,7 +368,7 @@ class ModelApi(metaclass=ModelMetaclass):
   @classmethod
   def save_batch(cls,
                  transaction: Optional[spanner_transaction.Transaction],
-                 models: List[ModelObject],
+                 models: List['ModelObject'],
                  force_write: bool = False) -> None:
     """Writes rows to Spanner based on the provided model data.
 
@@ -484,7 +482,7 @@ class Model(ModelApi):
     super().__setattr__(name, value)
 
   @property
-  def _metaclass(self) -> Type[Model]:
+  def _metaclass(self) -> Type['Model']:
     return type(self)
 
   @property
@@ -558,7 +556,7 @@ class Model(ModelApi):
 
   def reload(
       self,
-      transaction: spanner_transaction.Transaction = None) -> Optional[Model]:
+      transaction: spanner_transaction.Transaction = None) -> Optional['Model']:
     """Refreshes this object with information from Spanner.
 
     Args:
@@ -585,7 +583,8 @@ class Model(ModelApi):
     self._persisted = True
     return self
 
-  def save(self, transaction: spanner_transaction.Transaction = None) -> Model:
+  def save(self,
+           transaction: spanner_transaction.Transaction = None) -> 'Model':
     """Persists this object to Spanner.
 
     Note: if the _persisted flag doesn't match whether this object is actually

--- a/spanner_orm/registry.py
+++ b/spanner_orm/registry.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Registers Model classes so they can be referenced elsewhere."""
 
-from __future__ import annotations
-
 from typing import Any, Dict, List, Type, Union
 
 import dataclasses

--- a/spanner_orm/relationship.py
+++ b/spanner_orm/relationship.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Helps define a foreign key relationship between two models."""
 
-from __future__ import annotations
-
 from typing import Any, Dict, List, Type, Union
 
 import dataclasses

--- a/spanner_orm/table_apis.py
+++ b/spanner_orm/table_apis.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Table-level API lambdas for Spanner transactions."""
 
-from __future__ import annotations
-
 import logging
 from typing import Any, Dict, Iterable, List
 

--- a/spanner_orm/tests/migrations_test.py
+++ b/spanner_orm/tests/migrations_test.py
@@ -15,6 +15,9 @@
 import logging
 import os
 import unittest
+import stat
+import shutil
+import tempfile
 from unittest import mock
 
 from spanner_orm import error
@@ -25,11 +28,13 @@ from spanner_orm.admin import update
 
 
 class MigrationsTest(unittest.TestCase):
-  TEST_DIR = os.path.dirname(__file__)
+  TEST_DIR = tempfile.mkdtemp()
   TEST_MIGRATIONS_DIR = os.path.join(TEST_DIR, 'migrations')
 
   def test_retrieve(self):
-    manager = migration_manager.MigrationManager(self.TEST_MIGRATIONS_DIR)
+    testdata_filename = os.path.join(os.path.dirname(__file__),
+                                     'migrations')
+    manager = migration_manager.MigrationManager(testdata_filename)
     migrations = manager.migrations
     self.assertEqual(len(migrations), 3)
     self.assertEqual(migrations[2].prev_migration_id,
@@ -38,6 +43,16 @@ class MigrationsTest(unittest.TestCase):
                      migrations[0].migration_id)
 
   def test_generate(self):
+    testdata_filename = os.path.join(os.path.dirname(__file__),
+                                     'migrations')
+    shutil.rmtree(self.TEST_MIGRATIONS_DIR)
+    shutil.copytree(testdata_filename, self.TEST_MIGRATIONS_DIR)
+    os.chmod(self.TEST_MIGRATIONS_DIR,
+             stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH
+             | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+    for f in os.listdir(self.TEST_MIGRATIONS_DIR):
+      os.chmod(os.path.join(self.TEST_MIGRATIONS_DIR, f),
+               stat.S_IROTH | stat.S_IWOTH | stat.S_IRUSR | stat.S_IWUSR)
     manager = migration_manager.MigrationManager(self.TEST_MIGRATIONS_DIR)
     path = manager.generate('test migration')
     try:
@@ -47,7 +62,7 @@ class MigrationsTest(unittest.TestCase):
       self.assertIsInstance(migration_.upgrade(), update.NoUpdate)
       self.assertIsInstance(migration_.downgrade(), update.NoUpdate)
     finally:
-      os.remove(path)
+      shutil.rmtree(self.TEST_MIGRATIONS_DIR)
 
   def test_order_migrations(self):
     first = migration.Migration('1', None)
@@ -110,7 +125,7 @@ class MigrationsTest(unittest.TestCase):
 
   def test_filter_migrations(self):
     connection = mock.Mock()
-    executor = migration_executor.MigrationExecutor(connection)
+    executor = migration_executor.MigrationExecutor(connection, self.TEST_MIGRATIONS_DIR)
 
     first = migration.Migration('1', None)
     second = migration.Migration('2', '1')
@@ -130,7 +145,7 @@ class MigrationsTest(unittest.TestCase):
 
   def test_filter_migrations_error_on_bad_last_migration(self):
     connection = mock.Mock()
-    executor = migration_executor.MigrationExecutor(connection)
+    executor = migration_executor.MigrationExecutor(connection, self.TEST_MIGRATIONS_DIR)
 
     first = migration.Migration('1', None)
     second = migration.Migration('2', '1')
@@ -147,7 +162,7 @@ class MigrationsTest(unittest.TestCase):
 
   def test_validate_migrations(self):
     connection = mock.Mock()
-    executor = migration_executor.MigrationExecutor(connection)
+    executor = migration_executor.MigrationExecutor(connection, self.TEST_MIGRATIONS_DIR)
 
     first = migration.Migration('1', None)
     second = migration.Migration('2', '1')
@@ -165,7 +180,7 @@ class MigrationsTest(unittest.TestCase):
 
   def test_validate_migrations_error_on_unmigrated_after_migrated(self):
     connection = mock.Mock()
-    executor = migration_executor.MigrationExecutor(connection)
+    executor = migration_executor.MigrationExecutor(connection, self.TEST_MIGRATIONS_DIR)
 
     first = migration.Migration('1', None)
     second = migration.Migration('2', '1')
@@ -185,7 +200,7 @@ class MigrationsTest(unittest.TestCase):
 
   def test_validate_migrations_error_on_unmigrated_first(self):
     connection = mock.Mock()
-    executor = migration_executor.MigrationExecutor(connection)
+    executor = migration_executor.MigrationExecutor(connection, self.TEST_MIGRATIONS_DIR)
 
     first = migration.Migration('2', '1')
     with mock.patch.object(executor, 'migrations') as migrations:
@@ -203,7 +218,7 @@ class MigrationsTest(unittest.TestCase):
 
   def test_migrate(self):
     connection = mock.Mock()
-    executor = migration_executor.MigrationExecutor(connection)
+    executor = migration_executor.MigrationExecutor(connection, self.TEST_MIGRATIONS_DIR)
 
     first = migration.Migration('1', None)
     second = migration.Migration('2', '1')
@@ -217,7 +232,7 @@ class MigrationsTest(unittest.TestCase):
 
   def test_rollback(self):
     connection = mock.Mock()
-    executor = migration_executor.MigrationExecutor(connection)
+    executor = migration_executor.MigrationExecutor(connection, self.TEST_MIGRATIONS_DIR)
 
     first = migration.Migration('1', None)
     second = migration.Migration('2', '1')

--- a/spanner_orm/tests/migrations_test.py
+++ b/spanner_orm/tests/migrations_test.py
@@ -14,10 +14,10 @@
 # limitations under the License.
 import logging
 import os
-import unittest
-import stat
 import shutil
+import stat
 import tempfile
+import unittest
 from unittest import mock
 
 from spanner_orm import error
@@ -48,11 +48,12 @@ class MigrationsTest(unittest.TestCase):
     shutil.rmtree(self.TEST_MIGRATIONS_DIR)
     shutil.copytree(testdata_filename, self.TEST_MIGRATIONS_DIR)
     os.chmod(self.TEST_MIGRATIONS_DIR,
-             stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH
-             | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+             stat.S_IRWXO | stat.S_IRWXU)
     for f in os.listdir(self.TEST_MIGRATIONS_DIR):
-      os.chmod(os.path.join(self.TEST_MIGRATIONS_DIR, f),
-               stat.S_IROTH | stat.S_IWOTH | stat.S_IRUSR | stat.S_IWUSR)
+      file_path = os.path.join(self.TEST_MIGRATIONS_DIR, f)
+      if not os.path.isdir(file_path):
+        os.chmod(file_path,
+                 stat.S_IROTH | stat.S_IWOTH | stat.S_IRUSR | stat.S_IWUSR)
     manager = migration_manager.MigrationManager(self.TEST_MIGRATIONS_DIR)
     path = manager.generate('test migration')
     try:
@@ -125,7 +126,8 @@ class MigrationsTest(unittest.TestCase):
 
   def test_filter_migrations(self):
     connection = mock.Mock()
-    executor = migration_executor.MigrationExecutor(connection, self.TEST_MIGRATIONS_DIR)
+    executor = migration_executor.MigrationExecutor(
+        connection, self.TEST_MIGRATIONS_DIR)
 
     first = migration.Migration('1', None)
     second = migration.Migration('2', '1')
@@ -145,7 +147,8 @@ class MigrationsTest(unittest.TestCase):
 
   def test_filter_migrations_error_on_bad_last_migration(self):
     connection = mock.Mock()
-    executor = migration_executor.MigrationExecutor(connection, self.TEST_MIGRATIONS_DIR)
+    executor = migration_executor.MigrationExecutor(
+        connection, self.TEST_MIGRATIONS_DIR)
 
     first = migration.Migration('1', None)
     second = migration.Migration('2', '1')
@@ -162,7 +165,8 @@ class MigrationsTest(unittest.TestCase):
 
   def test_validate_migrations(self):
     connection = mock.Mock()
-    executor = migration_executor.MigrationExecutor(connection, self.TEST_MIGRATIONS_DIR)
+    executor = migration_executor.MigrationExecutor(
+        connection, self.TEST_MIGRATIONS_DIR)
 
     first = migration.Migration('1', None)
     second = migration.Migration('2', '1')
@@ -180,7 +184,8 @@ class MigrationsTest(unittest.TestCase):
 
   def test_validate_migrations_error_on_unmigrated_after_migrated(self):
     connection = mock.Mock()
-    executor = migration_executor.MigrationExecutor(connection, self.TEST_MIGRATIONS_DIR)
+    executor = migration_executor.MigrationExecutor(
+        connection, self.TEST_MIGRATIONS_DIR)
 
     first = migration.Migration('1', None)
     second = migration.Migration('2', '1')
@@ -200,7 +205,8 @@ class MigrationsTest(unittest.TestCase):
 
   def test_validate_migrations_error_on_unmigrated_first(self):
     connection = mock.Mock()
-    executor = migration_executor.MigrationExecutor(connection, self.TEST_MIGRATIONS_DIR)
+    executor = migration_executor.MigrationExecutor(
+        connection, self.TEST_MIGRATIONS_DIR)
 
     first = migration.Migration('2', '1')
     with mock.patch.object(executor, 'migrations') as migrations:
@@ -218,7 +224,8 @@ class MigrationsTest(unittest.TestCase):
 
   def test_migrate(self):
     connection = mock.Mock()
-    executor = migration_executor.MigrationExecutor(connection, self.TEST_MIGRATIONS_DIR)
+    executor = migration_executor.MigrationExecutor(
+        connection, self.TEST_MIGRATIONS_DIR)
 
     first = migration.Migration('1', None)
     second = migration.Migration('2', '1')
@@ -232,7 +239,8 @@ class MigrationsTest(unittest.TestCase):
 
   def test_rollback(self):
     connection = mock.Mock()
-    executor = migration_executor.MigrationExecutor(connection, self.TEST_MIGRATIONS_DIR)
+    executor = migration_executor.MigrationExecutor(
+        connection, self.TEST_MIGRATIONS_DIR)
 
     first = migration.Migration('1', None)
     second = migration.Migration('2', '1')
@@ -244,6 +252,10 @@ class MigrationsTest(unittest.TestCase):
         executor.rollback('1')
         self.assertEqual(migrated, {'1': False, '2': False, '3': False})
 
+  @classmethod
+  def tearDownClass(cls):
+    super().tearDownClass()
+    shutil.rmtree(MigrationsTest.TEST_DIR)
 
 if __name__ == '__main__':
   logging.basicConfig()


### PR DESCRIPTION
Stop deferring type annotation validation to prevent further divergence.
Prevent the migrations_test from modifying migrations in place.
Update documentation on how to create the database.
Don't validate migration_id in migrations/__init__.py.