### PR TITLE
Add support for setting foreign keys

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     include_package_data=True,
     python_requires='~=3.7',
     install_requires=['google-cloud-spanner >= 1.6, <2.0.0dev'],
-    tests_require=['absl-py', 'portpicker'],
+    tests_require=['absl-py', 'google-api-core', 'portpicker'],
     entry_points={
         'console_scripts': ['spanner-orm = spanner_orm.admin.scripts:main']
     })

--- a/spanner_orm/admin/update.py
+++ b/spanner_orm/admin/update.py
@@ -54,13 +54,12 @@ class CreateTable(SchemaUpdate):
         for name, field in self._model.fields.items()
     ]
     key_fields_ddl = ', '.join(key_fields)
-    if self._model.foreign_key_relations:
-      fk =  list(self._model.foreign_key_relations.values())[0]
-      for referencing_table_col, referenced_table_col in fk.constraints.items():
+    for relation in self._model.foreign_key_relations.values():
+      for referencing_table_col, referenced_table_col in relation.constraints.items():
         key_fields_ddl += (
           ', FOREIGN KEY ({referencing_table_col}) REFERENCES'
           ' {parent} ({referenced_table_col})').format(
-            parent=fk.destination,
+            parent=relation.destination,
             referencing_table_col=referencing_table_col,
             referenced_table_col=referenced_table_col,
           )

--- a/spanner_orm/admin/update.py
+++ b/spanner_orm/admin/update.py
@@ -55,14 +55,14 @@ class CreateTable(SchemaUpdate):
     ]
     key_fields_ddl = ', '.join(key_fields)
     for relation in self._model.foreign_key_relations.values():
-      for referencing_table_col, referenced_table_col in relation.constraints.items():
+      for constraint in relation.constraints:
         key_fields_ddl += (
-          ', FOREIGN KEY ({referencing_table_col}) REFERENCES'
-          ' {parent} ({referenced_table_col})').format(
-            parent=relation.destination,
-            referencing_table_col=referencing_table_col,
-            referenced_table_col=referenced_table_col,
-          )
+            ', FOREIGN KEY ({referencing_column}) REFERENCES'
+            ' {referenced_table} ({referenced_column})').format(
+                referencing_column=constraint.referencing_column,
+                referenced_table=constraint.referenced_table_name,
+                referenced_column=constraint.referenced_column,
+            )
     index_ddl = 'PRIMARY KEY ({})'.format(', '.join(self._model.primary_keys))
     statement = 'CREATE TABLE {} ({}) {}'.format(self._model.table,
                                                  key_fields_ddl, index_ddl)

--- a/spanner_orm/foreign_key_relationship.py
+++ b/spanner_orm/foreign_key_relationship.py
@@ -22,11 +22,11 @@ from spanner_orm import registry
 
 
 @dataclasses.dataclass
-class RelationshipConstraint:
-  destination_class: Type[Any]
-  destination_column: str
-  origin_class: Type[Any]
-  origin_column: str
+class ForeignKeyRelationshipConstraint:
+  referencing_column: str
+  referenced_columns: str
+  referenced_table_name: str
+  
 
 
 class ForeignKeyRelationship(object):
@@ -43,6 +43,7 @@ class ForeignKeyRelationship(object):
       constraints: Dictionary where the keys are names of columns from the
         referencing table and the values are the names of the columns in the
         referenced table.
+      # TODO(dgorelik): Allow constraints to have custom names.
     """
     self.origin = None
     self.name = None
@@ -50,22 +51,18 @@ class ForeignKeyRelationship(object):
     self._constraints = constraints
 
   @property
-  def constraints(self) -> List[RelationshipConstraint]:
+  def constraints(self) -> List[ForeignKeyRelationshipConstraint]:
     return self._constraints
 
   @property
   def destination(self) -> Type[Any]:
-    return self._referenced_table_name
+    return registry.model_registry().get(self._referenced_table_name).table
     if not self._destination:
       self._destination = registry.model_registry().get(
           self._referenced_table_name)
     return self._destination
 
-  @property
-  def single(self) -> bool:
-    return self._single
-
-  def _parse_constraints(self) -> List[RelationshipConstraint]:
+  def _parse_constraints(self) -> List[ForeignKeyRelationshipConstraint]:
     """Validates the dictionary of constraints and turns it into Conditions."""
     constraints = []
     for origin_column, destination_column in self._constraints.items():

--- a/spanner_orm/foreign_key_relationship.py
+++ b/spanner_orm/foreign_key_relationship.py
@@ -1,0 +1,85 @@
+# python3
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helps define a foreign key relationship between two models."""
+
+from typing import Any, List, Mapping, Type, Union
+
+import dataclasses
+from spanner_orm import error
+from spanner_orm import registry
+
+
+@dataclasses.dataclass
+class RelationshipConstraint:
+  destination_class: Type[Any]
+  destination_column: str
+  origin_class: Type[Any]
+  origin_column: str
+
+
+class ForeignKeyRelationship(object):
+  """Helps define a foreign key relationship between two models."""
+
+  def __init__(self,
+               referenced_table_name: str,
+               constraints: Mapping[str, str]):
+    """Creates a ForeignKeyRelationship.
+
+    Args:
+      referenced_table_name: Destination model class or fully qualified class
+        name of the destination model.
+      constraints: Dictionary where the keys are names of columns from the
+        referencing table and the values are the names of the columns in the
+        referenced table.
+    """
+    self.origin = None
+    self.name = None
+    self._referenced_table_name = referenced_table_name
+    self._constraints = constraints
+
+  @property
+  def constraints(self) -> List[RelationshipConstraint]:
+    return self._constraints
+
+  @property
+  def destination(self) -> Type[Any]:
+    return self._referenced_table_name
+    if not self._destination:
+      self._destination = registry.model_registry().get(
+          self._referenced_table_name)
+    return self._destination
+
+  @property
+  def single(self) -> bool:
+    return self._single
+
+  def _parse_constraints(self) -> List[RelationshipConstraint]:
+    """Validates the dictionary of constraints and turns it into Conditions."""
+    constraints = []
+    for origin_column, destination_column in self._constraints.items():
+      if origin_column not in self.origin.fields:
+        raise error.ValidationError(
+            'Origin column must be present in origin model')
+
+      if destination_column not in self.destination.fields:
+        raise error.ValidationError(
+           'Destination column must be present in destination model')
+
+      # TODO(dbrandao): remove when pytype #234 is fixed
+      constraints.append(
+          RelationshipConstraint(self.destination, destination_column,
+                                 self.origin, origin_column))  # type: ignore
+
+    return constraints

--- a/spanner_orm/metadata.py
+++ b/spanner_orm/metadata.py
@@ -32,6 +32,7 @@ from typing import Any, Dict, Type, Optional
 
 from spanner_orm import error
 from spanner_orm import field
+from spanner_orm import foreign_key_relationship
 from spanner_orm import index
 from spanner_orm import registry
 from spanner_orm import relationship
@@ -44,6 +45,7 @@ class ModelMetadata(object):
                table: Optional[str] = None,
                fields: Optional[Dict[str, field.Field]] = None,
                relations: Optional[Dict[str, relationship.Relationship]] = None,
+               foreign_key_relations: Optional[Dict[str, foreign_key_relationship.ForeignKeyRelationship]] = None,
                indexes: Optional[Dict[str, index.Index]] = None,
                interleaved: Optional[str] = None,
                model_class: Optional[Type[Any]] = None):
@@ -55,6 +57,7 @@ class ModelMetadata(object):
     self.model_class = model_class
     self.primary_keys = []
     self.relations = dict(relations or {})
+    self.foreign_key_relations = dict(foreign_key_relations or {})
     self.table = table or ''
 
   def finalize(self) -> None:
@@ -100,6 +103,14 @@ class ModelMetadata(object):
                    new_relation: relationship.Relationship) -> None:
     new_relation.name = name
     self.relations[name] = new_relation
+
+  def add_foreign_key_relation(
+      self,
+      name: str,
+      new_relation: foreign_key_relationship.ForeignKeyRelationship,
+  ) -> None:
+    new_relation.name = name
+    self.foreign_key_relations[name] = new_relation
 
   def add_index(self, name: str, new_index: index.Index) -> None:
     new_index.name = name

--- a/spanner_orm/metadata.py
+++ b/spanner_orm/metadata.py
@@ -45,7 +45,11 @@ class ModelMetadata(object):
                table: Optional[str] = None,
                fields: Optional[Dict[str, field.Field]] = None,
                relations: Optional[Dict[str, relationship.Relationship]] = None,
-               foreign_key_relations: Optional[Dict[str, foreign_key_relationship.ForeignKeyRelationship]] = None,
+               foreign_key_relations: Optional[
+                 Dict[
+                   str,
+                   foreign_key_relationship.ForeignKeyRelationship]
+               ] = None,
                indexes: Optional[Dict[str, index.Index]] = None,
                interleaved: Optional[str] = None,
                model_class: Optional[Type[Any]] = None):

--- a/spanner_orm/model.py
+++ b/spanner_orm/model.py
@@ -21,6 +21,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Type, TypeVar,
 from spanner_orm import api
 from spanner_orm import condition
 from spanner_orm import error
+from spanner_orm import foreign_key_relationship
 from spanner_orm import field
 from spanner_orm import index
 from spanner_orm import metadata
@@ -52,12 +53,19 @@ class ModelMetaclass(type):
         model_metadata.table = value
       elif key == '__interleaved__':
         model_metadata.interleaved = value
+      elif key == '__foreign_key__':
+        model_metadata.foreign_key = value
       if isinstance(value, field.Field):
         model_metadata.add_field(key, value)
       elif isinstance(value, index.Index):
         model_metadata.add_index(key, value)
       elif isinstance(value, relationship.Relationship):
         model_metadata.add_relation(key, value)
+      elif isinstance(
+          value,
+          foreign_key_relationship.ForeignKeyRelationship,
+      ):
+        model_metadata.add_foreign_key_relation(key, value)
       else:
         non_model_attrs[key] = value
 
@@ -111,6 +119,14 @@ class ModelMetaclass(type):
   @property
   def relations(cls) -> Dict[str, relationship.Relationship]:
     return cls.meta.relations
+
+  @property
+  def foreign_key_relations(cls) -> Dict[str, foreign_key_relationship.ForeignKeyRelationship]:
+    return cls.meta.foreign_key_relations
+    #if cls.meta.foreign_key:
+    #  return registry.model_registry().get(cls.meta.foreign_key)
+    #return None
+
 
   @property
   def fields(cls) -> Dict[str, field.Field]:

--- a/spanner_orm/model.py
+++ b/spanner_orm/model.py
@@ -53,8 +53,6 @@ class ModelMetaclass(type):
         model_metadata.table = value
       elif key == '__interleaved__':
         model_metadata.interleaved = value
-      elif key == '__foreign_key__':
-        model_metadata.foreign_key = value
       if isinstance(value, field.Field):
         model_metadata.add_field(key, value)
       elif isinstance(value, index.Index):
@@ -121,11 +119,9 @@ class ModelMetaclass(type):
     return cls.meta.relations
 
   @property
-  def foreign_key_relations(cls) -> Dict[str, foreign_key_relationship.ForeignKeyRelationship]:
+  def foreign_key_relations(
+      cls) -> Dict[str, foreign_key_relationship.ForeignKeyRelationship]:
     return cls.meta.foreign_key_relations
-    #if cls.meta.foreign_key:
-    #  return registry.model_registry().get(cls.meta.foreign_key)
-    #return None
 
 
   @property

--- a/spanner_orm/tests/migrations_emulator_test.py
+++ b/spanner_orm/tests/migrations_emulator_test.py
@@ -12,11 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import datetime
 import logging
 import os
 import unittest
 
 
+from google.api_core import exceptions as google_api_exceptions
 import spanner_orm
 from spanner_orm.tests import models
 from spanner_orm.testlib.spanner_emulator import testlib as spanner_emulator_testlib
@@ -38,6 +40,35 @@ class MigrationsEmulatorTest(spanner_emulator_testlib.TestCase):
       [x.values for x in models.SmallTestModel.all()],
       [{'key': 'key', 'value_1': 'value', 'value_2': None}],
     )
+
+  def test_error_with_missing_referencing_key(self):
+    with self.assertRaisesRegex(
+        google_api_exceptions.FailedPrecondition,
+        'Cannot find referenced key',
+    ):
+      models.ForeignKeyTestModel({
+        'referencing_key_1': 'key',
+        'referencing_key_2': 'key',
+        'referencing_key_3': 42,
+        'value': 'value'
+      }).save()
+
+  def test_key(self):
+    test_model = models.SmallTestModel({'key': 'key', 'value_1': 'value'})
+    test_model.save()
+    models.UnittestModel(
+      {'string': 'string',
+       'int_': 42,
+       'float_': 4.2,
+       'timestamp': datetime.datetime.now(tz=datetime.timezone.utc),
+      }).save()
+    test_model_2 = models.ForeignKeyTestModel({
+        'referencing_key_1': 'key',
+        'referencing_key_2': 'string',
+        'referencing_key_3': 42,
+        'value': 'value'
+      })
+    test_model_2.save()
 
 if __name__ == '__main__':
   logging.basicConfig()

--- a/spanner_orm/tests/migrations_emulator_test.py
+++ b/spanner_orm/tests/migrations_emulator_test.py
@@ -17,11 +17,11 @@ import logging
 import os
 import unittest
 
+from spanner_orm.testlib.spanner_emulator import testlib as spanner_emulator_testlib
+from spanner_orm.tests import models
 
 from google.api_core import exceptions as google_api_exceptions
-import spanner_orm
-from spanner_orm.tests import models
-from spanner_orm.testlib.spanner_emulator import testlib as spanner_emulator_testlib
+
 
 class MigrationsEmulatorTest(spanner_emulator_testlib.TestCase):
   TEST_MIGRATIONS_DIR = os.path.join(
@@ -34,8 +34,7 @@ class MigrationsEmulatorTest(spanner_emulator_testlib.TestCase):
     self.run_orm_migrations(self.TEST_MIGRATIONS_DIR)
 
   def test_basic(self):
-    test_model = models.SmallTestModel({'key': 'key', 'value_1': 'value'})
-    test_model.save()
+    models.SmallTestModel({'key': 'key', 'value_1': 'value'}).save()
     self.assertEqual(
       [x.values for x in models.SmallTestModel.all()],
       [{'key': 'key', 'value_1': 'value', 'value_2': None}],
@@ -54,21 +53,19 @@ class MigrationsEmulatorTest(spanner_emulator_testlib.TestCase):
       }).save()
 
   def test_key(self):
-    test_model = models.SmallTestModel({'key': 'key', 'value_1': 'value'})
-    test_model.save()
+    models.SmallTestModel({'key': 'key', 'value_1': 'value'}).save()
     models.UnittestModel(
       {'string': 'string',
        'int_': 42,
        'float_': 4.2,
        'timestamp': datetime.datetime.now(tz=datetime.timezone.utc),
       }).save()
-    test_model_2 = models.ForeignKeyTestModel({
+    models.ForeignKeyTestModel({
         'referencing_key_1': 'key',
         'referencing_key_2': 'string',
         'referencing_key_3': 42,
         'value': 'value'
-      })
-    test_model_2.save()
+      }).save()
 
 if __name__ == '__main__':
   logging.basicConfig()

--- a/spanner_orm/tests/migrations_for_emulator_test/create_foreign_key_test_model.py
+++ b/spanner_orm/tests/migrations_for_emulator_test/create_foreign_key_test_model.py
@@ -1,0 +1,44 @@
+# Lint as: python3
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Creates table with SmallTestModel.
+
+Migration ID: 'f735d6b706d3'
+Created: 2020-07-10 16:24
+"""
+
+import spanner_orm
+from spanner_orm import field
+
+migration_id = 'f735d6b706d3'
+prev_migration_id = 'f735d6b706d2'
+
+
+class OriginalForeignKeyTestModelTable(spanner_orm.model.Model):
+  """ORM Model with the original schema for the ForeignKeyTestModel table."""
+
+  __table__ = 'ForeignKeyTestModel'
+  __foreign_key__ = 'SmallTestModel'
+  key = field.Field(field.String, primary_key=True)
+  child_key = field.Field(field.String, primary_key=True)
+
+
+def upgrade() -> spanner_orm.CreateTable:
+  """See ORM migrations interface."""
+  return spanner_orm.CreateTable(OriginalForeignKeyTestModelTable)
+
+
+def downgrade() -> spanner_orm.DropTable:
+  """See ORM migrations interface."""
+  return spanner_orm.DropTable(OriginalForeignKeyTestModelTable.__table__)

--- a/spanner_orm/tests/migrations_for_emulator_test/create_foreign_key_test_model.py
+++ b/spanner_orm/tests/migrations_for_emulator_test/create_foreign_key_test_model.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Creates table with SmallTestModel.
+"""Creates table with ForeignKeyTestModel.
 
 Migration ID: 'f735d6b706d3'
 Created: 2020-07-10 16:24
@@ -20,18 +20,26 @@ Created: 2020-07-10 16:24
 
 import spanner_orm
 from spanner_orm import field
+from spanner_orm import foreign_key_relationship
 
-migration_id = 'f735d6b706d3'
-prev_migration_id = 'f735d6b706d2'
+migration_id = 'f735d6b706d4'
+prev_migration_id = 'f735d6b706d3'
 
 
 class OriginalForeignKeyTestModelTable(spanner_orm.model.Model):
   """ORM Model with the original schema for the ForeignKeyTestModel table."""
 
   __table__ = 'ForeignKeyTestModel'
-  __foreign_key__ = 'SmallTestModel'
-  key = field.Field(field.String, primary_key=True)
-  child_key = field.Field(field.String, primary_key=True)
+  referencing_key_1 = field.Field(field.String, primary_key=True)
+  referencing_key_2 = field.Field(field.String, primary_key=True)
+  referencing_key_3 = field.Field(field.Integer, primary_key=True)
+  value = field.Field(field.String)
+  foreign_key_1 = foreign_key_relationship.ForeignKeyRelationship(
+      'SmallTestModel', {'referencing_key_1': 'key'})
+  foreign_key_2 = foreign_key_relationship.ForeignKeyRelationship(
+    'UnittestModel',
+    {'referencing_key_2': 'string', 'referencing_key_3': 'int_'},
+  )
 
 
 def upgrade() -> spanner_orm.CreateTable:

--- a/spanner_orm/tests/models.py
+++ b/spanner_orm/tests/models.py
@@ -15,6 +15,7 @@
 """Models used by unit tests."""
 
 from spanner_orm import field
+from spanner_orm import foreign_key_relationship
 from spanner_orm import index
 from spanner_orm import model
 from spanner_orm import relationship
@@ -61,6 +62,18 @@ class RelationshipTestModel(model.Model):
   parents = relationship.Relationship('spanner_orm.tests.models.SmallTestModel',
                                       {'parent_key': 'key'})
 
+class ForeignKeyTestModel(model.Model):
+  """Model class for testing foreign keys."""
+
+  __table__ = 'ForeignKeyTestModel'
+ # __foreign_key__ = 'SmallTestModel'
+  referencing_key = field.Field(field.String, primary_key=True)
+  value = field.Field(field.String)
+  foreign_key_relationship = foreign_key_relationship.ForeignKeyRelationship(
+      'SmallTestModel', {'referencing_key': 'key'})
+  #    single=True)
+  #parents = relationship.Relationship('spanner_orm.tests.models.SmallTestModel',
+  #                                    {'parent_key': 'key'})
 
 class InheritanceTestModel(SmallTestModel):
   """Model class used for testing model inheritance."""

--- a/spanner_orm/tests/models.py
+++ b/spanner_orm/tests/models.py
@@ -66,14 +66,16 @@ class ForeignKeyTestModel(model.Model):
   """Model class for testing foreign keys."""
 
   __table__ = 'ForeignKeyTestModel'
- # __foreign_key__ = 'SmallTestModel'
-  referencing_key = field.Field(field.String, primary_key=True)
+  referencing_key_1 = field.Field(field.String, primary_key=True)
+  referencing_key_2 = field.Field(field.String, primary_key=True)
+  referencing_key_3 = field.Field(field.Integer, primary_key=True)
   value = field.Field(field.String)
-  foreign_key_relationship = foreign_key_relationship.ForeignKeyRelationship(
-      'SmallTestModel', {'referencing_key': 'key'})
-  #    single=True)
-  #parents = relationship.Relationship('spanner_orm.tests.models.SmallTestModel',
-  #                                    {'parent_key': 'key'})
+  foreign_key_1 = foreign_key_relationship.ForeignKeyRelationship(
+      'SmallTestModel', {'referencing_key_1': 'key'})
+  foreign_key_2 = foreign_key_relationship.ForeignKeyRelationship(
+    'UnittestModel',
+    {'referencing_key_2': 'string', 'referencing_key_3': 'int_'},
+  )
 
 class InheritanceTestModel(SmallTestModel):
   """Model class used for testing model inheritance."""

--- a/spanner_orm/tests/update_test.py
+++ b/spanner_orm/tests/update_test.py
@@ -87,6 +87,23 @@ class UpdateTest(unittest.TestCase):
     self.assertEqual(test_update.ddl(), test_model_ddl)
 
   @mock.patch('spanner_orm.admin.metadata.SpannerMetadata.model')
+  def test_create_table_foreign_key(self, get_model):
+    self.maxDiff = 1000
+    
+    get_model.return_value = None
+    new_model = models.ForeignKeyTestModel
+    test_update = update.CreateTable(new_model)
+    test_update.validate()
+
+    test_model_ddl = (
+        'CREATE TABLE ForeignKeyTestModel ('
+        'referencing_key STRING(MAX) NOT NULL, '
+        'value STRING(MAX) NOT NULL, '
+        'FOREIGN KEY (referencing_key) REFERENCES SmallTestModel (key)) '
+        'PRIMARY KEY (referencing_key)')
+    self.assertEqual(test_update.ddl(), test_model_ddl)
+
+  @mock.patch('spanner_orm.admin.metadata.SpannerMetadata.model')
   def test_create_table_error_on_existing_table(self, get_model):
     get_model.return_value = models.SmallTestModel
     new_model = models.SmallTestModel

--- a/spanner_orm/tests/update_test.py
+++ b/spanner_orm/tests/update_test.py
@@ -88,7 +88,7 @@ class UpdateTest(unittest.TestCase):
 
   @mock.patch('spanner_orm.admin.metadata.SpannerMetadata.model')
   def test_create_table_foreign_key(self, get_model):
-    self.maxDiff = 1000
+    self.maxDiff = 2000
     
     get_model.return_value = None
     new_model = models.ForeignKeyTestModel
@@ -97,10 +97,14 @@ class UpdateTest(unittest.TestCase):
 
     test_model_ddl = (
         'CREATE TABLE ForeignKeyTestModel ('
-        'referencing_key STRING(MAX) NOT NULL, '
+        'referencing_key_1 STRING(MAX) NOT NULL, '
+        'referencing_key_2 STRING(MAX) NOT NULL, '
+        'referencing_key_3 INT64 NOT NULL, '
         'value STRING(MAX) NOT NULL, '
-        'FOREIGN KEY (referencing_key) REFERENCES SmallTestModel (key)) '
-        'PRIMARY KEY (referencing_key)')
+        'FOREIGN KEY (referencing_key_1) REFERENCES SmallTestModel (key), '
+        'FOREIGN KEY (referencing_key_2) REFERENCES table (string), '
+        'FOREIGN KEY (referencing_key_3) REFERENCES table (int_)) '
+        'PRIMARY KEY (referencing_key_1, referencing_key_2, referencing_key_3)')
     self.assertEqual(test_update.ddl(), test_model_ddl)
 
   @mock.patch('spanner_orm.admin.metadata.SpannerMetadata.model')


### PR DESCRIPTION
This PR adds basic support for adding [Cloud Spanner foreign keys](https://cloud.google.com/spanner/docs/foreign-keys/overview) in migrations.

Functionality to remove a foreign key relationship will be added in a follow-up PR.