### PR TITLE
Add missing migration from PR#83

### DIFF
--- a/spanner_orm/tests/migrations_for_emulator_test/create_unittest_model.py
+++ b/spanner_orm/tests/migrations_for_emulator_test/create_unittest_model.py
@@ -1,0 +1,48 @@
+# Lint as: python3
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Creates table with UnittestModel.
+
+Migration ID: 'f735d6b706d3'
+Created: 2020-07-10 16:24
+"""
+
+import spanner_orm
+from spanner_orm import field
+
+migration_id = 'f735d6b706d3'
+prev_migration_id = 'f735d6b706d2'
+
+
+class OriginalUnittestModelTable(spanner_orm.model.Model):
+  """ORM Model with the original schema for the UnittestModel table."""
+
+  __table__ = 'table'
+  int_ = field.Field(field.Integer, primary_key=True)
+  int_2 = field.Field(field.Integer, nullable=True)
+  float_ = field.Field(field.Float, primary_key=True)
+  float_2 = field.Field(field.Float, nullable=True)
+  string = field.Field(field.String, primary_key=True)
+  string_2 = field.Field(field.String, nullable=True)
+  timestamp = field.Field(field.Timestamp)
+  string_array = field.Field(field.StringArray, nullable=True)
+
+def upgrade() -> spanner_orm.CreateTable:
+  """See ORM migrations interface."""
+  return spanner_orm.CreateTable(OriginalUnittestModelTable)
+
+
+def downgrade() -> spanner_orm.DropTable:
+  """See ORM migrations interface."""
+  return spanner_orm.DropTable(OriginalUnittestModelTable.__table__)


### PR DESCRIPTION
Add missing migration which should have been part of https://github.com/google/python-spanner-orm/pull/83. It would be good to set up CI to avoid this in the future.