### PR TITLE
Get pytype to pass

### DIFF
--- a/spanner_orm/admin/migration_manager.py
+++ b/spanner_orm/admin/migration_manager.py
@@ -74,6 +74,7 @@ class MigrationManager:
     path = os.path.join(self.basedir, filename)
     spec = importlib.util.spec_from_file_location(module_name, path)
     module = importlib.util.module_from_spec(spec)
+    # TODO(#93): Remove pytype disable below.
     spec.loader.exec_module(module)  # type: ignore
     try:
       result = migration.Migration(module.migration_id,

--- a/spanner_orm/admin/migration_manager.py
+++ b/spanner_orm/admin/migration_manager.py
@@ -74,7 +74,7 @@ class MigrationManager:
     path = os.path.join(self.basedir, filename)
     spec = importlib.util.spec_from_file_location(module_name, path)
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    spec.loader.exec_module(module)  # type: ignore
     try:
       result = migration.Migration(module.migration_id,
                                    module.prev_migration_id,

--- a/spanner_orm/model.py
+++ b/spanner_orm/model.py
@@ -307,7 +307,7 @@ class ModelApi(metaclass=ModelMetaclass):
   def _results_to_models(cls,
                          results: Iterable[Iterable[Any]]) -> List['ModelObject']:
     items = [dict(zip(cls.columns, result)) for result in results]
-    return [cls(item, persisted=True) for item in items]
+    return [cls(item, persisted=True) for item in items]  # type: ignore
 
   @classmethod
   def _execute_read(cls, db_api: Callable[..., CallableReturn],

--- a/spanner_orm/model.py
+++ b/spanner_orm/model.py
@@ -307,6 +307,7 @@ class ModelApi(metaclass=ModelMetaclass):
   def _results_to_models(cls,
                          results: Iterable[Iterable[Any]]) -> List['ModelObject']:
     items = [dict(zip(cls.columns, result)) for result in results]
+    # TODO(#93): Remove pytype disable below.
     return [cls(item, persisted=True) for item in items]  # type: ignore
 
   @classmethod

--- a/spanner_orm/query.py
+++ b/spanner_orm/query.py
@@ -15,7 +15,7 @@
 """Helps build SQL for complex Spanner queries."""
 
 import abc
-from typing import Any, Dict, Iterable, List, Tuple, Type
+from typing import Any, Dict, Iterable, List, Sequence, Tuple, Type
 
 from spanner_orm import condition
 from spanner_orm import error
@@ -47,7 +47,7 @@ class SpannerQuery(abc.ABC):
     return self._types
 
   @abc.abstractmethod
-  def process_results(self, results: List[List[Any]]) -> None:
+  def process_results(self, results: List[Sequence[Any]]) -> None:
     pass
 
   def _segments(self,
@@ -148,7 +148,7 @@ class CountQuery(SpannerQuery):
   def _select(self) -> Tuple[str, Dict[str, Any], Dict[str, Any]]:
     return ('SELECT COUNT(*)', {}, {})
 
-  def process_results(self, results: List[List[Any]]) -> int:
+  def process_results(self, results: List[Sequence[Any]]) -> int:
     return int(results[0][0])
 
 
@@ -186,7 +186,7 @@ class SelectQuery(SpannerQuery):
         prefix=self._select_prefix(),
         columns=', '.join(columns)), parameters, types)
 
-  def process_results(self, results: List[List[Any]]) -> List[Type[Any]]:
+  def process_results(self, results: List[Sequence[Any]]) -> List[Type[Any]]:
     return [self._process_row(result) for result in results]
 
   def _process_row(self, row: List[Any]) -> Type[Any]:

--- a/spanner_orm/relationship.py
+++ b/spanner_orm/relationship.py
@@ -88,9 +88,8 @@ class Relationship(object):
         raise error.ValidationError(
             'Destination column must be present in destination model')
 
-      # TODO(dbrandao): remove when pytype #234 is fixed
       constraints.append(
           RelationshipConstraint(self.destination, destination_column,
-                                 self.origin, origin_column))  # type: ignore
+                                 self.origin, origin_column))
 
     return constraints

--- a/spanner_orm/table_apis.py
+++ b/spanner_orm/table_apis.py
@@ -15,7 +15,7 @@
 """Table-level API lambdas for Spanner transactions."""
 
 import logging
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable, List, Sequence
 
 from google.cloud import spanner
 from google.cloud.spanner_v1 import transaction as spanner_transaction
@@ -26,7 +26,7 @@ _logger = logging.getLogger(__name__)
 
 # Read methods
 def find(transaction: spanner_transaction.Transaction, table_name: str,
-         columns: Iterable[str], keyset: spanner.KeySet) -> List[Iterable[Any]]:
+         columns: Iterable[str], keyset: spanner.KeySet) -> List[Sequence[Any]]:
   """Retrieves rows from the given table based on the provided KeySet.
 
   Args:
@@ -51,7 +51,7 @@ def find(transaction: spanner_transaction.Transaction, table_name: str,
 
 def sql_query(transaction: spanner_transaction.Transaction, query: str,
               parameters: Dict[str, Any],
-              parameter_types: Dict[str, type_pb2.Type]) -> List[Iterable[Any]]:
+              parameter_types: Dict[str, type_pb2.Type]) -> List[Sequence[Any]]:
   """Executes a given SQL query against the Spanner database.
 
   This isn't technically read-only, but it's necessary to implement the read-

--- a/spanner_orm/tests/metadata_test.py
+++ b/spanner_orm/tests/metadata_test.py
@@ -12,6 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# type: ignore
+
 import logging
 import unittest
 

--- a/spanner_orm/tests/metadata_test.py
+++ b/spanner_orm/tests/metadata_test.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO(#93): Remove pytype disable below.
 # type: ignore
 
 import logging


### PR DESCRIPTION
This PR includes the following changes to get pytype to pass at HEAD:

* Remove `ignore`  in `relationship.py` now that pytype issue #234 is fixed. 
* Switch `table_apis.find` and `table_apis.query` to return a list of sequences, and `query.SpannerQuery.processResults` to accept a list of sequences, so that values can be passes between those methods successfully.
* Disable pytype with a TODO if the error was related to metaclasses or `importlib`.