### PR TITLE
Make pytype infer the correct instance attribute type.

### DIFF
--- a/spanner_orm/admin/column.py
+++ b/spanner_orm/admin/column.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Model for interacting with Spanner column schema table."""
 
+import typing
 from typing import Type
 
 from spanner_orm import error
@@ -25,13 +26,13 @@ class ColumnSchema(schema.InformationSchema):
   """Model for interacting with Spanner column schema table."""
 
   __table__ = 'information_schema.columns'
-  table_catalog = field.Field(field.String, primary_key=True)
-  table_schema = field.Field(field.String, primary_key=True)
-  table_name = field.Field(field.String, primary_key=True)
-  column_name = field.Field(field.String, primary_key=True)
-  ordinal_position = field.Field(field.Integer)
-  is_nullable = field.Field(field.String)
-  spanner_type = field.Field(field.String)
+  table_catalog = typing.cast(str, field.Field(field.String, primary_key=True))
+  table_schema = typing.cast(str, field.Field(field.String, primary_key=True))
+  table_name = typing.cast(str, field.Field(field.String, primary_key=True))
+  column_name = typing.cast(str, field.Field(field.String, primary_key=True))
+  ordinal_position = typing.cast(int, field.Field(field.Integer))
+  is_nullable = typing.cast(str, field.Field(field.String))
+  spanner_type = typing.cast(str, field.Field(field.String))
 
   def nullable(self) -> bool:
     return self.is_nullable == 'YES'

--- a/spanner_orm/admin/index.py
+++ b/spanner_orm/admin/index.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 """Model for interacting with Spanner index schema table."""
 
+import typing
+from typing import Optional
+
 from spanner_orm import field
 from spanner_orm.admin import schema
 
@@ -22,12 +25,13 @@ class IndexSchema(schema.InformationSchema):
   """Model for interacting with Spanner index schema table."""
 
   __table__ = 'information_schema.indexes'
-  table_catalog = field.Field(field.String, primary_key=True)
-  table_schema = field.Field(field.String, primary_key=True)
-  table_name = field.Field(field.String, primary_key=True)
-  index_name = field.Field(field.String, primary_key=True)
-  index_type = field.Field(field.String)
-  parent_table_name = field.Field(field.String, nullable=True)
-  is_unique = field.Field(field.Boolean)
-  is_null_filtered = field.Field(field.Boolean)
-  index_state = field.Field(field.String)
+  table_catalog = typing.cast(str, field.Field(field.String, primary_key=True))
+  table_schema = typing.cast(str, field.Field(field.String, primary_key=True))
+  table_name = typing.cast(str, field.Field(field.String, primary_key=True))
+  index_name = typing.cast(str, field.Field(field.String, primary_key=True))
+  index_type = typing.cast(str, field.Field(field.String))
+  parent_table_name = typing.cast(Optional[str],
+                                  field.Field(field.String, nullable=True))
+  is_unique = typing.cast(bool, field.Field(field.Boolean))
+  is_null_filtered = typing.cast(bool, field.Field(field.Boolean))
+  index_state = typing.cast(str, field.Field(field.String))

--- a/spanner_orm/admin/index_column.py
+++ b/spanner_orm/admin/index_column.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 """Model for interacting with Spanner index column schema table."""
 
+import typing
+from typing import Optional
+
 from spanner_orm import field
 from spanner_orm.admin import schema
 
@@ -22,12 +25,14 @@ class IndexColumnSchema(schema.InformationSchema):
   """Model for interacting with Spanner index column schema table."""
 
   __table__ = 'information_schema.index_columns'
-  table_catalog = field.Field(field.String, primary_key=True)
-  table_schema = field.Field(field.String, primary_key=True)
-  table_name = field.Field(field.String, primary_key=True)
-  index_name = field.Field(field.String, primary_key=True)
-  column_name = field.Field(field.String, primary_key=True)
-  ordinal_position = field.Field(field.Integer, nullable=True)
-  column_ordering = field.Field(field.String, nullable=True)
-  is_nullable = field.Field(field.String)
-  spanner_type = field.Field(field.String)
+  table_catalog = typing.cast(str, field.Field(field.String, primary_key=True))
+  table_schema = typing.cast(str, field.Field(field.String, primary_key=True))
+  table_name = typing.cast(str, field.Field(field.String, primary_key=True))
+  index_name = typing.cast(str, field.Field(field.String, primary_key=True))
+  column_name = typing.cast(str, field.Field(field.String, primary_key=True))
+  ordinal_position = typing.cast(Optional[int],
+                                 field.Field(field.Integer, nullable=True))
+  column_ordering = typing.cast(Optional[str],
+                                field.Field(field.String, nullable=True))
+  is_nullable = typing.cast(str, field.Field(field.String))
+  spanner_type = typing.cast(str, field.Field(field.String))

--- a/spanner_orm/admin/migration_status.py
+++ b/spanner_orm/admin/migration_status.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 """Indicates whether a migration has been applied to the current database."""
 
+import datetime
+import typing
+
 from spanner_orm import field
 from spanner_orm import model
 from spanner_orm.admin import api
@@ -26,6 +29,6 @@ class MigrationStatus(model.Model):
     return api.spanner_admin_api()
 
   __table__ = 'spanner_orm_migrations'
-  id = field.Field(field.String, primary_key=True)
-  migrated = field.Field(field.Boolean)
-  update_time = field.Field(field.Timestamp)
+  id = typing.cast(str, field.Field(field.String, primary_key=True))
+  migrated = typing.cast(bool, field.Field(field.Boolean))
+  update_time = typing.cast(datetime.datetime, field.Field(field.Timestamp))

--- a/spanner_orm/admin/table.py
+++ b/spanner_orm/admin/table.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 """Model for interacting with Spanner column schema table."""
 
+import typing
+from typing import Optional
+
 from spanner_orm import field
 from spanner_orm.admin import schema
 
@@ -22,8 +25,10 @@ class TableSchema(schema.InformationSchema):
   """Model for interacting with Spanner column schema table."""
 
   __table__ = 'information_schema.tables'
-  table_catalog = field.Field(field.String, primary_key=True)
-  table_schema = field.Field(field.String, primary_key=True)
-  table_name = field.Field(field.String, primary_key=True)
-  parent_table_name = field.Field(field.String, nullable=True)
-  on_delete_action = field.Field(field.String, nullable=True)
+  table_catalog = typing.cast(str, field.Field(field.String, primary_key=True))
+  table_schema = typing.cast(str, field.Field(field.String, primary_key=True))
+  table_name = typing.cast(str, field.Field(field.String, primary_key=True))
+  parent_table_name = typing.cast(Optional[str],
+                                  field.Field(field.String, nullable=True))
+  on_delete_action = typing.cast(Optional[str],
+                                 field.Field(field.String, nullable=True))


### PR DESCRIPTION
Fields have class attributes of type Field, but instance attributes of
the specific field type (int, str, etc.) This commit is a hack to get
instance attributes to play nicely with pytype. See #97 for a better
long-term solution.

Addresses #93.