### PR TITLE
Give all ModelMetaclass classes a `meta` attribute.

### DIFF
--- a/spanner_orm/model.py
+++ b/spanner_orm/model.py
@@ -35,11 +35,10 @@ from google.cloud.spanner_v1 import transaction as spanner_transaction
 
 class ModelMetaclass(type):
   """Populates ModelMetadata based on class attributes."""
+  meta: metadata.ModelMetadata
 
   def __new__(mcs, name: str, bases: Any, attrs: Dict[str, Any], **kwargs: Any):
     parents = [base for base in bases if isinstance(base, ModelMetaclass)]
-    if not parents:
-      return super().__new__(mcs, name, bases, attrs, **kwargs)
 
     model_metadata = metadata.ModelMetadata()
     for parent in parents:

--- a/spanner_orm/tests/metadata_test.py
+++ b/spanner_orm/tests/metadata_test.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#93): Remove pytype disable below.
-# type: ignore
-
 import logging
 import unittest
 


### PR DESCRIPTION
This fixes bugs where pytype got the type for `meta` wrong because it
only existed on some classes. I'm not 100% sure adding a default (empty)
metadata to classes that didn't previously have it makes sense, but
tests pass and it seems likely to be safe to me.

This change also has the side effect of parsing Model-specific
attributes from the Model class itself (as opposed to just subclasses of
Model), but it doesn't look like Model has any attributes that would be
affected.

Addresses #93.

Tested: Ran tests and pytype.