### PR TITLE
Allow tuples with in_list

### DIFF
--- a/spanner_orm/condition.py
+++ b/spanner_orm/condition.py
@@ -485,8 +485,8 @@ class ListComparisonCondition(ComparisonCondition):
     return {self._column_key: list_type}
 
   def _validate(self, model_class: Type[Any]) -> None:
-    if not isinstance(self.value, list):
-      raise error.ValidationError('{} is not a list'.format(self.value))
+    if not isinstance(self.value, Iterable):
+      raise error.ValidationError('{} is not iterable'.format(self.value))
     if self.column not in model_class.fields:
       raise error.ValidationError('{} is not a column on {}'.format(
           self.column, model_class.table))

--- a/spanner_orm/tests/query_test.py
+++ b/spanner_orm/tests/query_test.py
@@ -165,6 +165,7 @@ class QueryTest(parameterized.TestCase):
 
   @parameterized.parameters(
       ('int_', [1, 2, 3], field.Integer.grpc_type()),
+      ('int_', (4, 5, 6), field.Integer.grpc_type()),
       ('string', ['a', 'b', 'c'], field.String.grpc_type()),
       ('timestamp', [now()], field.Timestamp.grpc_type()))
   def test_query_where_list_comparison(self, column, values, grpc_type):


### PR DESCRIPTION
I've found myself trying to construct some queries like:

```python
states = [
    CONST_1,
    CONST_2,
    CONST_3,
]
spanner_orm.in_list('my-column', states)
```

I'd like to make `states` a tuple because it's a list with a constant set of items but Spanner ORM's type checking is overly restrictive. This PR allows the value passed into `in_list` to be any kind of iterable instead of just lists.