### PR TITLE
End the module docstring one liner with punctuation.

### DIFF
--- a/spanner_orm/admin/migration.skel
+++ b/spanner_orm/admin/migration.skel
@@ -1,4 +1,4 @@
-"""Spanner ORM migration: $migration_name
+"""Spanner ORM migration: $migration_name.
 
 Migration ID: $migration_id
 Created: $current_date


### PR DESCRIPTION
One of our internal lints requires that.

Tested: manually