### PR TITLE
Make option-like parameters (mostly `transaction`) keyword-only.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,23 +84,24 @@ The two main ways of retrieving data through the ORM are ```where()``` and
 ```find()```/```find_multi()```:
 
 ``` python
-# where() is invokes on a model class to retrieve models of that tyep. it takes a
-# transaction and then a sequence of conditions.
-# Most conditions that specify a Field, Index, Relationship, or Model can take
-# either the name of the object or the object itself
-test_objects = TestModel.where(None, spanner_orm.greater_than('value', '50'))
+# where() is invokes on a model class to retrieve models of that type. it takes
+# a sequence of conditions. Most conditions that specify a Field, Index,
+# Relationship, or Model can take  either the name of the object or the object
+# itself
+test_objects = TestModel.where(spanner_orm.greater_than('value', '50'))
 
 # To also retrieve related objects, the includes() condition should be used:
-test_and_other_objects = TestModel.where(None,
-                                         spanner_orm.greater_than(TestModel.value, '50'),
-                                         spanner_orm.includes(TestModel.fake_relationship))
+test_and_other_objects = TestModel.where(
+    spanner_orm.greater_than(TestModel.value, '50'),
+    spanner_orm.includes(TestModel.fake_relationship),
+)
 
 # To create a transaction, run_read_only() or run_write() are used with the
 # method to be run inside the transaction and any arguments to passs to the method.
 # The method is invoked with the transaction as the first argument and then the
 # rest of the provided arguments:
 def callback_1(transaction, argument):
-  return TestModel.find(transaction, id=argument)
+  return TestModel.find(id=argument, transaction=transaction)
 
 specific_object = spanner_orm.spanner_api().run_read_only(callback, 1)
 
@@ -108,7 +109,7 @@ specific_object = spanner_orm.spanner_api().run_read_only(callback, 1)
 # call a bit:
 @transactional_read
 def finder(argument, transaction=None):
-  return TestModel.find(transaction, id=argument)
+  return TestModel.find(id=argument, transaction=transaction)
 specific_object = finder(1)
 ```
 
@@ -131,7 +132,7 @@ models = []
 for i in range(10):
   key = 'test_{}'.format(i)
   models.append(TestModel({'key': key, 'value': value}))
-TestModel.save_batch(None, models)
+TestModel.save_batch(models)
 ```
 
 ```spanner_orm.spanner_api().run_write()``` can be used for executing read-write

--- a/spanner_orm/admin/metadata.py
+++ b/spanner_orm/admin/metadata.py
@@ -71,9 +71,10 @@ class SpannerMetadata(object):
   def tables(cls) -> Dict[str, Dict[str, Any]]:
     """Compiles table information from column schema."""
     column_data = collections.defaultdict(dict)
-    columns = column.ColumnSchema.where(None,
-                                        condition.equal_to('table_catalog', ''),
-                                        condition.equal_to('table_schema', ''))
+    columns = column.ColumnSchema.where(
+        condition.equal_to('table_catalog', ''),
+        condition.equal_to('table_schema', ''),
+    )
     for column_row in columns:
       new_field = field.Field(
           column_row.field_type(), nullable=column_row.nullable())
@@ -82,9 +83,10 @@ class SpannerMetadata(object):
       column_data[column_row.table_name][column_row.column_name] = new_field
 
     table_data = collections.defaultdict(dict)
-    tables = table.TableSchema.where(None,
-                                     condition.equal_to('table_catalog', ''),
-                                     condition.equal_to('table_schema', ''))
+    tables = table.TableSchema.where(
+        condition.equal_to('table_catalog', ''),
+        condition.equal_to('table_schema', ''),
+    )
     for table_row in tables:
       name = table_row.table_name
       table_data[name]['parent_table'] = table_row.parent_table_name
@@ -98,9 +100,10 @@ class SpannerMetadata(object):
     # Results are ordered by that so the index columns are added in the
     # correct order.
     index_column_schemas = index_column.IndexColumnSchema.where(
-        None, condition.equal_to('table_catalog', ''),
+        condition.equal_to('table_catalog', ''),
         condition.equal_to('table_schema', ''),
-        condition.order_by(('ordinal_position', condition.OrderType.ASC)))
+        condition.order_by(('ordinal_position', condition.OrderType.ASC)),
+    )
 
     index_columns = collections.defaultdict(list)
     storing_columns = collections.defaultdict(list)
@@ -112,8 +115,9 @@ class SpannerMetadata(object):
         storing_columns[key].append(schema.column_name)
 
     index_schemas = index_schema.IndexSchema.where(
-        None, condition.equal_to('table_catalog', ''),
-        condition.equal_to('table_schema', ''))
+        condition.equal_to('table_catalog', ''),
+        condition.equal_to('table_schema', ''),
+    )
     indexes = collections.defaultdict(dict)
     for schema in index_schemas:
       key = (schema.table_name, schema.index_name)

--- a/spanner_orm/admin/migration_executor.py
+++ b/spanner_orm/admin/migration_executor.py
@@ -165,8 +165,7 @@ class MigrationExecutor:
         'migrated': new_status,
         'update_time': datetime.datetime.utcnow(),
     })
-    migration_status.MigrationStatus.save_batch(
-        None, [new_model], force_write=True)
+    migration_status.MigrationStatus.save_batch([new_model], force_write=True)
     self._migration_status()[migration_id] = new_status
 
   def _validate_migrations(self) -> None:

--- a/spanner_orm/admin/update.py
+++ b/spanner_orm/admin/update.py
@@ -182,8 +182,9 @@ class DropColumn(SchemaUpdate):
 
     # Verify no indices exist on the column we're trying to drop
     num_indexed_columns = index_column.IndexColumnSchema.count(
-        None, condition.equal_to('column_name', self._column),
-        condition.equal_to('table_name', self._table))
+        condition.equal_to('column_name', self._column),
+        condition.equal_to('table_name', self._table),
+    )
     if num_indexed_columns > 0:
       raise error.SpannerError('Column {} is indexed'.format(self._column))
 

--- a/spanner_orm/tests/query_test.py
+++ b/spanner_orm/tests/query_test.py
@@ -37,7 +37,7 @@ class QueryTest(parameterized.TestCase):
   def test_where(self, sql_query):
     sql_query.return_value = []
 
-    models.UnittestModel.where_equal(True, int_=3)
+    models.UnittestModel.where_equal(int_=3, transaction=True)
     (_, sql, parameters, types), _ = sql_query.call_args
 
     expected_sql = 'SELECT .* FROM table WHERE table.int_ = @int_0'
@@ -49,7 +49,7 @@ class QueryTest(parameterized.TestCase):
   def test_count(self, sql_query):
     sql_query.return_value = [[0]]
     column, value = 'int_', 3
-    models.UnittestModel.count_equal(True, int_=3)
+    models.UnittestModel.count_equal(int_=3, transaction=True)
     (_, sql, parameters, types), _ = sql_query.call_args
 
     column_key = '{}0'.format(column)


### PR DESCRIPTION
Note that this change breaks the API, but I think it's worth it. In some
cases, e.g., where(), this avoids needing to pass an unnamed `None`
argument which I think is confusing. In the case of save_batch()'s
`force_write` parameter, I think this can avoid potentially bad bugs.
And in all cases, I think this makes the call sites more clear.

Additionally:

1. Make the `transaction` parameter optional for all methods.
2. Fix some type annotations on those parameters.