### PR TITLE
Raise an error if a CreateTable update has secondary indexes.

### DIFF
--- a/spanner_orm/admin/update.py
+++ b/spanner_orm/admin/update.py
@@ -20,6 +20,7 @@ from typing import Iterable, List, Optional, Type
 from spanner_orm import condition
 from spanner_orm import error
 from spanner_orm import field
+from spanner_orm import index
 from spanner_orm import model
 from spanner_orm.admin import api
 from spanner_orm.admin import index_column
@@ -76,6 +77,11 @@ class CreateTable(SchemaUpdate):
 
     self._validate_primary_keys()
 
+    if self._model.indexes.keys() - {index.Index.PRIMARY_INDEX}:
+      raise error.SpannerError(
+          'Secondary indexes cannot be created by CreateTable; use CreateIndex '
+          'in a separate migration.')
+
   def _validate_parent(self) -> None:
     """Verifies that the parent table information is valid."""
     parent_primary_keys = self._model.interleaved.primary_keys
@@ -129,10 +135,10 @@ class DropTable(SchemaUpdate):
       if model_.interleaved == existing_model:
         raise error.SpannerError('Table {} has interleaved table {}'.format(
             self._table, model_.table))
-      for index in model_.indexes.values():
-        if index.parent == self._table:
+      for index_ in model_.indexes.values():
+        if index_.parent == self._table:
           raise error.SpannerError('Table {} has interleaved index {}'.format(
-              self._table, index.name))
+              self._table, index_.name))
 
 
 class AddColumn(SchemaUpdate):

--- a/spanner_orm/tests/models.py
+++ b/spanner_orm/tests/models.py
@@ -81,3 +81,16 @@ class UnittestModel(model.Model):
   string_array = field.Field(field.StringArray, nullable=True)
 
   test_index = index.Index(['string_2'])
+
+class UnittestModelWithoutSecondaryIndexes(model.Model):
+  """Same as UnittestModel, but with no secondary indexes."""
+
+  __table__ = 'table'
+  int_ = field.Field(field.Integer, primary_key=True)
+  int_2 = field.Field(field.Integer, nullable=True)
+  float_ = field.Field(field.Float, primary_key=True)
+  float_2 = field.Field(field.Float, nullable=True)
+  string = field.Field(field.String, primary_key=True)
+  string_2 = field.Field(field.String, nullable=True)
+  timestamp = field.Field(field.Timestamp)
+  string_array = field.Field(field.StringArray, nullable=True)

--- a/spanner_orm/tests/update_test.py
+++ b/spanner_orm/tests/update_test.py
@@ -61,7 +61,7 @@ class UpdateTest(unittest.TestCase):
   @mock.patch('spanner_orm.admin.metadata.SpannerMetadata.model')
   def test_create_table(self, get_model):
     get_model.return_value = None
-    new_model = models.UnittestModel
+    new_model = models.UnittestModelWithoutSecondaryIndexes
     test_update = update.CreateTable(new_model)
     test_update.validate()
 
@@ -92,6 +92,17 @@ class UpdateTest(unittest.TestCase):
     new_model = models.SmallTestModel
     test_update = update.CreateTable(new_model)
     with self.assertRaisesRegex(error.SpannerError, 'already exists'):
+      test_update.validate()
+
+  @mock.patch('spanner_orm.admin.metadata.SpannerMetadata.model')
+  def test_create_table_error_on_table_with_index(self, get_model):
+    get_model.return_value = None
+    new_model = models.IndexTestModel
+    test_update = update.CreateTable(new_model)
+    with self.assertRaisesRegex(
+        error.SpannerError,
+        'indexes cannot be created',
+    ):
       test_update.validate()
 
   @mock.patch('spanner_orm.admin.metadata.SpannerMetadata.indexes')


### PR DESCRIPTION
The current CreateTable DDL doesn't support them, and I don't see any
way to create a table and its secondary indexes in a single DDL
statement:
https://cloud.google.com/spanner/docs/data-definition-language#create_table