### PR TITLE
Use abspath() instead of realpath() for migrations directories.

### DIFF
--- a/spanner_orm/tests/condition_test.py
+++ b/spanner_orm/tests/condition_test.py
@@ -40,7 +40,7 @@ class ConditionTest(
     super().setUp()
     self.run_orm_migrations(
         os.path.join(
-            os.path.dirname(os.path.realpath(__file__)),
+            os.path.dirname(os.path.abspath(__file__)),
             'migrations_for_emulator_test',
         ))
 

--- a/spanner_orm/tests/migrations_emulator_test.py
+++ b/spanner_orm/tests/migrations_emulator_test.py
@@ -23,7 +23,7 @@ from spanner_orm.testlib.spanner_emulator import testlib as spanner_emulator_tes
 
 class MigrationsEmulatorTest(spanner_emulator_testlib.TestCase):
   TEST_MIGRATIONS_DIR = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)),
+    os.path.dirname(os.path.abspath(__file__)),
     'migrations_for_emulator_test',
   )
 

--- a/spanner_orm/tests/model_test.py
+++ b/spanner_orm/tests/model_test.py
@@ -39,7 +39,7 @@ class ModelTest(
     super().setUp()
     self.run_orm_migrations(
         os.path.join(
-            os.path.dirname(os.path.realpath(__file__)),
+            os.path.dirname(os.path.abspath(__file__)),
             'migrations_for_emulator_test',
         ))
 


### PR DESCRIPTION
Resolving symlinks seems to break the tests in some environments, and I
can't think of a reason it would be necessary.