### PR TITLE
Make it possible to add non-DDL migration updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ Running ```spanner-orm generate <migration name>``` will generate a new
 migration file to be filled out in the directory specified (or 'migrations' by
 default). The ```upgrade``` function is executed when migrating, and the
 ```downgrade``` function is executed when rolling back the migration. Each of
-these should return a single SchemaUpdate object (e.g., CreateTable, AddColumn,
-etc.), as Spanner cannot execute multiple schema updates atomically.
+these should return a single MigrationUpdate object (e.g., CreateTable,
+AddColumn, etc.), as Spanner cannot execute multiple schema updates atomically.
 
 ### Executing migrations
 Running ```spanner-orm migrate <Spanner instance> <Spanner database>``` will

--- a/spanner_orm/__init__.py
+++ b/spanner_orm/__init__.py
@@ -95,6 +95,8 @@ order_by = condition.order_by
 transactional_read = decorator.transactional_read
 transactional_write = decorator.transactional_write
 
+MigrationUpdate = update_module.MigrationUpdate
+NoUpdate = update_module.NoUpdate
 SchemaUpdate = update_module.SchemaUpdate
 CreateTable = update_module.CreateTable
 DropTable = update_module.DropTable
@@ -103,7 +105,6 @@ DropColumn = update_module.DropColumn
 AlterColumn = update_module.AlterColumn
 CreateIndex = update_module.CreateIndex
 DropIndex = update_module.DropIndex
-NoUpdate = update_module.NoUpdate
 model_creation_ddl = update_module.model_creation_ddl
 
 MigrationExecutor = migration_executor.MigrationExecutor

--- a/spanner_orm/admin/migration.py
+++ b/spanner_orm/admin/migration.py
@@ -19,18 +19,20 @@ from typing import Callable, Optional
 from spanner_orm.admin import update
 
 
-def no_update_callable() -> update.SchemaUpdate:
+def no_update_callable() -> update.MigrationUpdate:
   return update.NoUpdate()
 
 
 class Migration:
   """Holds information about a specific migration."""
 
-  def __init__(self,
-               migration_id: str,
-               prev_migration_id: Optional[str],
-               upgrade: Optional[Callable[[], update.SchemaUpdate]] = None,
-               downgrade: Optional[Callable[[], update.SchemaUpdate]] = None):
+  def __init__(
+      self,
+      migration_id: str,
+      prev_migration_id: Optional[str],
+      upgrade: Optional[Callable[[], update.MigrationUpdate]] = None,
+      downgrade: Optional[Callable[[], update.MigrationUpdate]] = None,
+  ):
     self._id = migration_id
     self._prev = prev_migration_id
     self._upgrade = upgrade or no_update_callable
@@ -45,9 +47,9 @@ class Migration:
     return self._prev
 
   @property
-  def upgrade(self) -> Optional[Callable[[], update.SchemaUpdate]]:
+  def upgrade(self) -> Optional[Callable[[], update.MigrationUpdate]]:
     return self._upgrade
 
   @property
-  def downgrade(self) -> Optional[Callable[[], update.SchemaUpdate]]:
+  def downgrade(self) -> Optional[Callable[[], update.MigrationUpdate]]:
     return self._downgrade

--- a/spanner_orm/admin/migration.skel
+++ b/spanner_orm/admin/migration.skel
@@ -10,11 +10,11 @@ migration_id = $migration_id
 prev_migration_id = $prev_migration_id
 
 
-def upgrade() -> spanner_orm.SchemaUpdate:
+def upgrade() -> spanner_orm.MigrationUpdate:
   """See spanner_orm migrations interface."""
   return spanner_orm.NoUpdate()
 
 
-def downgrade() -> spanner_orm.SchemaUpdate:
+def downgrade() -> spanner_orm.MigrationUpdate:
   """See spanner_orm migrations interface."""
   return spanner_orm.NoUpdate()

--- a/spanner_orm/admin/migration_executor.py
+++ b/spanner_orm/admin/migration_executor.py
@@ -66,12 +66,12 @@ class MigrationExecutor:
                                          target_migration)
     for migration_ in migrations:
       _logger.info('Processing migration %s', migration_.migration_id)
-      schema_update = migration_.upgrade()
-      if not isinstance(schema_update, update.SchemaUpdate):
+      migration_update = migration_.upgrade()
+      if not isinstance(migration_update, update.MigrationUpdate):
         raise error.SpannerError(
-            'Migration {} did not return a SchemaUpdate'.format(
+            'Migration {} did not return a MigrationUpdate'.format(
                 migration_.migration_id))
-      schema_update.execute()
+      migration_update.execute()
 
       self._update_status(migration_.migration_id, True)
     self._hangup()
@@ -97,12 +97,12 @@ class MigrationExecutor:
         reversed(self.migrations()), True, target_migration)
     for migration_ in migrations:
       _logger.info('Processing migration %s', migration_.migration_id)
-      schema_update = migration_.downgrade()
-      if not isinstance(schema_update, update.SchemaUpdate):
+      migration_update = migration_.downgrade()
+      if not isinstance(migration_update, update.MigrationUpdate):
         raise error.SpannerError(
-            'Migration {} did not return a SchemaUpdate'.format(
+            'Migration {} did not return a MigrationUpdate'.format(
                 migration_.migration_id))
-      schema_update.execute()
+      migration_update.execute()
 
       self._update_status(migration_.migration_id, False)
     self._hangup()

--- a/spanner_orm/admin/update.py
+++ b/spanner_orm/admin/update.py
@@ -28,7 +28,23 @@ from spanner_orm.admin import index_column
 from spanner_orm.admin import metadata
 
 
-class SchemaUpdate(abc.ABC):
+class MigrationUpdate(abc.ABC):
+  """Base class for all updates that can happen in a migration."""
+
+  @abc.abstractmethod
+  def execute(self) -> None:
+    """Executes the update."""
+    raise NotImplementedError
+
+
+class NoUpdate(MigrationUpdate):
+  """Update that does nothing, for migrations that don't update db schemas."""
+
+  def execute(self) -> None:
+    """See base class."""
+
+
+class SchemaUpdate(MigrationUpdate, abc.ABC):
   """Base class for specifying schema updates."""
 
   @abc.abstractmethod
@@ -334,19 +350,6 @@ class DropIndex(SchemaUpdate):
     if db_index.primary:
       raise error.SpannerError('Index {} is the primary index'.format(
           self._index))
-
-
-class NoUpdate(SchemaUpdate):
-  """Update that does nothing, for migrations that don't update db schemas."""
-
-  def ddl(self) -> str:
-    return ''
-
-  def execute(self) -> None:
-    pass
-
-  def validate(self) -> None:
-    pass
 
 
 def model_creation_ddl(model_: Type[model.Model]) -> List[str]:


### PR DESCRIPTION
SchemaUpdate seems to be designed for DDL (schema) changes, but there
currently doesn't seem to be any way to add a `NOT NULL` column using
only DDL changes. This commit makes it easier to add non-DDL migration
updates; a follow-up commit will add support for backfilling data in a
migration update.