### PR TITLE
Add ExecutePartitionedDml migrations update.

### DIFF
--- a/spanner_orm/__init__.py
+++ b/spanner_orm/__init__.py
@@ -105,6 +105,7 @@ DropColumn = update_module.DropColumn
 AlterColumn = update_module.AlterColumn
 CreateIndex = update_module.CreateIndex
 DropIndex = update_module.DropIndex
+ExecutePartitionedDml = update_module.ExecutePartitionedDml
 model_creation_ddl = update_module.model_creation_ddl
 
 MigrationExecutor = migration_executor.MigrationExecutor

--- a/spanner_orm/admin/api.py
+++ b/spanner_orm/admin/api.py
@@ -44,6 +44,10 @@ class SpannerAdminApi(api.SpannerReadApi, api.SpannerWriteApi):
     operation = self._connection.update_ddl([change])
     operation.result()
 
+  def execute_partitioned_dml(self, dml: str) -> None:
+    """See spanner_database.Database.execute_partitioned_dml()."""
+    self._connection.execute_partitioned_dml(dml)
+
 
 _admin_api = None
 

--- a/spanner_orm/admin/update.py
+++ b/spanner_orm/admin/update.py
@@ -352,6 +352,21 @@ class DropIndex(SchemaUpdate):
           self._index))
 
 
+class ExecutePartitionedDml(MigrationUpdate):
+  """Update for running arbitrary partitioned DML.
+
+  See https://cloud.google.com/spanner/docs/dml-partitioned for more
+  information.
+  """
+
+  def __init__(self, dml: str):
+    self._dml = dml
+
+  def execute(self) -> None:
+    """See base class."""
+    api.spanner_admin_api().execute_partitioned_dml(self._dml)
+
+
 def model_creation_ddl(model_: Type[model.Model]) -> List[str]:
   """Returns the list of ddl statements needed to create the model's table."""
   ddl_list = [CreateTable(model_).ddl()]

--- a/spanner_orm/tests/models.py
+++ b/spanner_orm/tests/models.py
@@ -31,6 +31,14 @@ class SmallTestModel(model.Model):
   index_1 = index.Index(['value_1'])
 
 
+class SmallTestModelWithoutSecondaryIndexes(model.Model):
+  """Same as SmallTestModel, but with no secondary indexes."""
+  __table__ = 'SmallTestModel'
+  key = field.Field(field.String, primary_key=True)
+  value_1 = field.Field(field.String)
+  value_2 = field.Field(field.String, nullable=True)
+
+
 class ChildTestModel(model.Model):
   """Model class for testing interleaved tables."""
 


### PR DESCRIPTION
This makes it possible to backfill data from migrations, e.g., changing
NULL values to a non-NULL default before making a column `NOT NULL`.