### PR TITLE
Include seconds and timezone in migration timestamps.

### DIFF
--- a/spanner_orm/admin/migration_manager.py
+++ b/spanner_orm/admin/migration_manager.py
@@ -41,7 +41,8 @@ class MigrationManager:
     """Creates a new migration that is the last migration to be executed."""
     migration_id = uuid.uuid4().hex[-12:]
     prev_id = self.migrations[-1].migration_id if self.migrations else None
-    now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M')
+    now = datetime.datetime.now().astimezone().isoformat(
+        sep=' ', timespec='seconds')
 
     skeleton_directory = os.path.dirname(os.path.abspath(__file__))
     skeleton_file = os.path.join(skeleton_directory, 'migration.skel')


### PR DESCRIPTION
I think this could reduce confusion when there are multiple people
writing migrations in different timezones.

Tested:
  Manually created a migration, and it showed up as:
  2021-02-03 18:23:19-05:00