### PR TITLE
Deprecate connect() functions in favor of from_connection()

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ then run:
 To connect the Spanner ORM to an existing Spanner database:
 ``` python
 import spanner_orm
-spanner_orm.connect(instance_name, database_name)
+spanner_orm.from_connection(
+    spanner_orm.SpannerConnection(instance_name, database_name))
 ```
 
 `project` and `credentials` are optional parameters, and the standard Spanner

--- a/spanner_orm/admin/api.py
+++ b/spanner_orm/admin/api.py
@@ -15,6 +15,8 @@
 """Class that handles API calls to Spanner that deal with table metadata."""
 
 from typing import Iterable, Optional
+import warnings
+
 from spanner_orm import api
 from spanner_orm import error
 
@@ -58,7 +60,13 @@ def connect(instance: str,
             credentials: Optional[auth_credentials.Credentials] = None,
             pool: Optional[spanner_pool.AbstractSessionPool] = None,
             create_ddl: Optional[Iterable[str]] = None) -> SpannerAdminApi:
-  """Connects the global Spanner admin API to a Spanner database."""
+  """Connects the global Spanner admin API to a Spanner database.
+
+  Deprecated in favor of from_connection().
+  """
+  warnings.warn(
+      DeprecationWarning('Please use spanner_orm.from_admin_connection('
+                         'spanner_orm.SpannerConnection(...))'))
   connection = api.SpannerConnection(
       instance,
       database,

--- a/spanner_orm/api.py
+++ b/spanner_orm/api.py
@@ -16,6 +16,7 @@
 
 import abc
 from typing import Any, Callable, Dict, Iterable, Optional, TypeVar, Union
+import warnings
 
 from google.api_core import client_options as api_client_options
 from google.api_core import exceptions
@@ -160,7 +161,14 @@ def connect(
     project: Optional[str] = None,
     credentials: Optional[auth_credentials.Credentials] = None,
     pool: Optional[spanner_pool.AbstractSessionPool] = None) -> SpannerApi:
-  """Connects to the Spanner database and sets the global spanner_api."""
+  """Connects to the Spanner database and sets the global spanner_api.
+
+  Deprecated in favor of from_connection().
+  """
+  warnings.warn(
+      DeprecationWarning(
+          'Please use '
+          'spanner_orm.from_connection(spanner_orm.SpannerConnection(...))'))
   connection = SpannerConnection(
       instance, database, project=project, credentials=credentials, pool=pool)
   return from_connection(connection)


### PR DESCRIPTION
They provide the some functionality, but from_connection() functions are
more powerful since they let you store the connection information to use
multiple times. It doesn't seem worth the overhead of maintaining both
versions.