### PR TITLE
Parse ABSL flags when running tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,8 @@ jobs:
           google-api-core \
           'google-cloud-spanner >= 1.6, <2.0.0dev' \
           immutabledict \
-          portpicker
+          portpicker \
+          pytest
     - name: Check formatting
       run: |
         pip install yapf
@@ -58,4 +59,4 @@ jobs:
       env:
         SPANNER_EMULATOR_BINARY_PATH: ${{ github.workspace }}/emulator_main
       run: |
-        python setup.py test
+        pytest

--- a/README.md
+++ b/README.md
@@ -218,5 +218,5 @@ yapf --diff --recursive --parallel .
 Then run tests with:
 
 ```
-SPANNER_EMULATOR_BINARY_PATH=$(pwd)/emulator_main python3 setup.py test
+SPANNER_EMULATOR_BINARY_PATH=$(pwd)/emulator_main pytest
 ```

--- a/spanner_orm/tests/conftest.py
+++ b/spanner_orm/tests/conftest.py
@@ -1,0 +1,26 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pytest fixture."""
+
+import sys
+
+from absl import flags
+import pytest
+
+
+@pytest.fixture(scope='session', autouse=True)
+def parse_flags():
+  # Only pass the first item, because pytest flags shouldn't be parsed as absl
+  # flags.
+  flags.FLAGS(sys.argv[:1])


### PR DESCRIPTION
It looks like `python setup.py test`, `python -m unittest`, and `pytest`
all import test modules rather than running them as `__main__`, so the
usual parsing with absltest.main() doesn't work. This pytest fixture
seems to work though.