### PR TITLE
Don't check for interleaved indexes in DropTable

### DIFF
--- a/spanner_orm/admin/update.py
+++ b/spanner_orm/admin/update.py
@@ -155,10 +155,6 @@ class DropTable(SchemaUpdate):
       if model_.interleaved == existing_model:
         raise error.SpannerError('Table {} has interleaved table {}'.format(
             self._table, model_.table))
-      for index_ in model_.indexes.values():
-        if index_.parent == self._table:
-          raise error.SpannerError('Table {} has interleaved index {}'.format(
-              self._table, index_.name))
 
 
 class AddColumn(SchemaUpdate):


### PR DESCRIPTION
https://cloud.google.com/spanner/docs/data-definition-language#create-index-interleave
> If `T` is the table into which the index is interleaved, then:
> `T` must be a parent of the table being indexed

If I'm understanding that correctly, any table with an interleaved index
will also have an interleaved table too. We already check for
interleaved tables.