### PR TITLE
Add BytesBase64 support

### DIFF
--- a/spanner_orm/__init__.py
+++ b/spanner_orm/__init__.py
@@ -68,6 +68,7 @@ Relationship = relationship.Relationship
 String = field.String
 StringArray = field.StringArray
 Timestamp = field.Timestamp
+BytesBase64 = field.BytesBase64
 
 ArbitraryCondition = condition.ArbitraryCondition
 Column = condition.Column

--- a/spanner_orm/field.py
+++ b/spanner_orm/field.py
@@ -207,5 +207,7 @@ class BytesBase64(FieldType):
       raise error.ValidationError(
           '{} must be base64-encoded bytes.'.format(value))
 
-ALL_TYPES = [Boolean, Integer, Float, String, StringArray, Timestamp,
-             BytesBase64]
+
+ALL_TYPES = [
+    Boolean, Integer, Float, String, StringArray, Timestamp, BytesBase64
+]

--- a/spanner_orm/field.py
+++ b/spanner_orm/field.py
@@ -15,12 +15,13 @@
 """Helper to deal with field types in Spanner interactions."""
 
 import abc
+import base64
+import binascii
 import datetime
 from typing import Any, Type
 
-from spanner_orm import error
-
 from google.cloud.spanner_v1.proto import type_pb2
+from spanner_orm import error
 
 
 class FieldType(abc.ABC):
@@ -118,7 +119,7 @@ class Float(FieldType):
 
   @staticmethod
   def ddl() -> str:
-    return "FLOAT64"
+    return 'FLOAT64'
 
   @staticmethod
   def grpc_type() -> type_pb2.Type:
@@ -127,7 +128,7 @@ class Float(FieldType):
   @staticmethod
   def validate_type(value: Any) -> None:
     if not isinstance(value, (int, float)):
-      raise error.ValidationError("{} is not of type float".format(value))
+      raise error.ValidationError('{} is not of type float'.format(value))
 
 
 class String(FieldType):
@@ -184,4 +185,27 @@ class Timestamp(FieldType):
       raise error.ValidationError('{} is not of type datetime'.format(value))
 
 
-ALL_TYPES = [Boolean, Integer, Float, String, StringArray, Timestamp]
+class BytesBase64(FieldType):
+  """Represents a bytes type that must be base64 encoded."""
+
+  @staticmethod
+  def ddl() -> str:
+    return 'BYTES(MAX)'
+
+  @staticmethod
+  def grpc_type() -> type_pb2.Type:
+    return type_pb2.Type(code=type_pb2.BYTES)
+
+  @staticmethod
+  def validate_type(value) -> None:
+    if not isinstance(value, bytes):
+      raise error.ValidationError('{} is not of type bytes'.format(value))
+    # Rudimentary test to check for base64 encoding.
+    try:
+      base64.b64decode(value, altchars=None, validate=True)
+    except binascii.Error:
+      raise error.ValidationError(
+          '{} must be base64-encoded bytes.'.format(value))
+
+ALL_TYPES = [Boolean, Integer, Float, String, StringArray, Timestamp,
+             BytesBase64]

--- a/spanner_orm/tests/migrations_emulator_test.py
+++ b/spanner_orm/tests/migrations_emulator_test.py
@@ -70,6 +70,7 @@ class MigrationsEmulatorTest(spanner_emulator_testlib.TestCase):
         'string': 'string',
         'int_': 42,
         'float_': 4.2,
+        'bytes_': b'A1A1',
         'timestamp': datetime.datetime.now(tz=datetime.timezone.utc),
     }).save()
     models.ForeignKeyTestModel({

--- a/spanner_orm/tests/migrations_for_emulator_test/create_unittest_model.py
+++ b/spanner_orm/tests/migrations_for_emulator_test/create_unittest_model.py
@@ -35,6 +35,8 @@ class OriginalUnittestModelTable(spanner_orm.model.Model):
   float_2 = field.Field(field.Float, nullable=True)
   string = field.Field(field.String, primary_key=True)
   string_2 = field.Field(field.String, nullable=True)
+  bytes_ = field.Field(field.BytesBase64, primary_key=True)
+  bytes_2 = field.Field(field.BytesBase64, nullable=True)
   timestamp = field.Field(field.Timestamp)
   string_array = field.Field(field.StringArray, nullable=True)
 

--- a/spanner_orm/tests/model_test.py
+++ b/spanner_orm/tests/model_test.py
@@ -51,6 +51,7 @@ class ModelTest(
         string='string',
         int_=1,
         float_=2.3,
+        bytes_=b'A1A1',
         transaction=mock_transaction,
     )
 
@@ -59,7 +60,7 @@ class ModelTest(
     self.assertEqual(transaction, mock_transaction)
     self.assertEqual(table, models.UnittestModel.table)
     self.assertEqual(columns, models.UnittestModel.columns)
-    self.assertEqual(keyset.keys, [[1, 2.3, 'string']])
+    self.assertEqual(keyset.keys, [[1, 2.3, 'string', b'A1A1']])
 
   @mock.patch('spanner_orm.table_apis.find')
   def test_find_result(self, find):
@@ -98,6 +99,7 @@ class ModelTest(
     models.UnittestModel.find_multi(
         [{
             'string': 'string',
+            'bytes_': b'bytes',
             'int_': 1,
             'float_': 2.3
         }],
@@ -109,7 +111,7 @@ class ModelTest(
     self.assertEqual(transaction, mock_transaction)
     self.assertEqual(table, models.UnittestModel.table)
     self.assertEqual(columns, models.UnittestModel.columns)
-    self.assertEqual(keyset.keys, [[1, 2.3, 'string']])
+    self.assertEqual(keyset.keys, [[1, 2.3, 'string', b'bytes']])
 
   @mock.patch('spanner_orm.table_apis.find')
   def test_find_multi_result(self, find):
@@ -226,8 +228,8 @@ class ModelTest(
       test_model.key = 'error'
 
   @parameterized.parameters(('int_2', 'foo'), ('float_2', 'bar'),
-                            ('string_2', 5), ('string_array', 'foo'),
-                            ('timestamp', 5))
+                            ('string_2', 5), ('bytes_2', 'string'),
+                            ('string_array', 'foo'), ('timestamp', 5))
   def test_set_error_on_invalid_type(self, attribute, value):
     string_array = ['foo', 'bar']
     timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
@@ -235,6 +237,7 @@ class ModelTest(
         'int_': 0,
         'float_': 0,
         'string': '',
+        'bytes_': b'',
         'string_array': string_array,
         'timestamp': timestamp
     })
@@ -273,6 +276,7 @@ class ModelTest(
         'int_': 0,
         'float_': 0,
         'string': '',
+        'bytes_': b'',
         'string_array': ['foo', 'bar'],
         'timestamp': timestamp,
     })
@@ -280,6 +284,7 @@ class ModelTest(
         'int_': 0,
         'float_': 0.0,
         'string': '',
+        'bytes_': b'',
         'string_array': ['foo', 'bar'],
         'timestamp': timestamp,
     })
@@ -290,18 +295,21 @@ class ModelTest(
           'int_': 0,
           'float_': 0,
           'string': '1',
+          'bytes_': b'1111',
           'timestamp': _TIMESTAMP,
       }),
        models.UnittestModel({
            'int_': 0,
            'float_': 0,
            'string': 'a',
+           'bytes_': b'A1A1',
            'timestamp': _TIMESTAMP,
        })),
       (models.UnittestModel({
           'int_': 0,
           'float_': 0,
           'string': '',
+          'bytes_': b'A1A1',
           'string_array': ['foo', 'bar'],
           'timestamp': _TIMESTAMP,
       }),
@@ -309,6 +317,7 @@ class ModelTest(
            'int_': 0,
            'float_': 0,
            'string': '',
+           'bytes_': b'A1A1',
            'string_array': ['bar', 'foo'],
            'timestamp': _TIMESTAMP,
        })),
@@ -324,7 +333,7 @@ class ModelTest(
     self.assertNotEqual(test_model1, test_model2)
 
   def test_id(self):
-    primary_key = {'string': 'foo', 'int_': 5, 'float_': 2.3}
+    primary_key = {'string': 'foo', 'int_': 5, 'float_': 2.3, 'bytes_': b'A1A1'}
     all_data = primary_key.copy()
     all_data.update({
         'timestamp': datetime.datetime.now(tz=datetime.timezone.utc),
@@ -348,6 +357,7 @@ class ModelTest(
         'int_': 0,
         'float_': 0,
         'string': '',
+        'bytes_': b'',
         'string_array': array,
         'timestamp': timestamp
     })

--- a/spanner_orm/tests/models.py
+++ b/spanner_orm/tests/models.py
@@ -108,6 +108,8 @@ class UnittestModel(model.Model):
   float_2 = field.Field(field.Float, nullable=True)
   string = field.Field(field.String, primary_key=True)
   string_2 = field.Field(field.String, nullable=True)
+  bytes_ = field.Field(field.BytesBase64, primary_key=True)
+  bytes_2 = field.Field(field.BytesBase64, nullable=True)
   timestamp = field.Field(field.Timestamp)
   string_array = field.Field(field.StringArray, nullable=True)
 
@@ -124,5 +126,7 @@ class UnittestModelWithoutSecondaryIndexes(model.Model):
   float_2 = field.Field(field.Float, nullable=True)
   string = field.Field(field.String, primary_key=True)
   string_2 = field.Field(field.String, nullable=True)
+  bytes_ = field.Field(field.BytesBase64, primary_key=True)
+  bytes_2 = field.Field(field.BytesBase64, nullable=True)
   timestamp = field.Field(field.Timestamp)
   string_array = field.Field(field.StringArray, nullable=True)

--- a/spanner_orm/tests/update_test.py
+++ b/spanner_orm/tests/update_test.py
@@ -1,3 +1,4 @@
+
 # python3
 # Copyright 2019 Google LLC
 #
@@ -87,8 +88,10 @@ class UpdateTest(
     test_model_ddl = ('CREATE TABLE table (int_ INT64 NOT NULL, int_2 INT64,'
                       ' float_ FLOAT64 NOT NULL, float_2 FLOAT64,'
                       ' string STRING(MAX) NOT NULL, string_2 STRING(MAX),'
+                      ' bytes_ BYTES(MAX) NOT NULL, bytes_2 BYTES(MAX),'
                       ' timestamp TIMESTAMP NOT NULL, string_array'
-                      ' ARRAY<STRING(MAX)>) PRIMARY KEY (int_, float_, string)')
+                      ' ARRAY<STRING(MAX)>) PRIMARY KEY '
+                      '(int_, float_, string, bytes_)')
     self.assertEqual(test_update.ddl(), test_model_ddl)
 
   @mock.patch('spanner_orm.admin.metadata.SpannerMetadata.model')

--- a/spanner_orm/tests/update_test.py
+++ b/spanner_orm/tests/update_test.py
@@ -1,4 +1,3 @@
-
 # python3
 # Copyright 2019 Google LLC
 #


### PR DESCRIPTION
Basically identical to https://github.com/google/python-spanner-orm/pull/162. Using this as a workaround since checks were not running on that PR