### PR TITLE
Upgrade spanner-orm to work with google-cloud-spanner v2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='spanner-orm',
-    version='0.1.10',
+    version='0.2.0',
     description='Basic ORM for Spanner',
     maintainer='Python Spanner ORM developers',
     maintainer_email='python-spanner-orm@google.com',
@@ -26,7 +26,7 @@ setup(
     include_package_data=True,
     python_requires='~=3.7',
     install_requires=[
-        'google-cloud-spanner >= 1.6, <4',
+        'google-cloud-spanner >= 2, <4',
         'immutabledict',
     ],
     tests_require=['absl-py', 'google-api-core', 'portpicker'],

--- a/spanner_orm/field.py
+++ b/spanner_orm/field.py
@@ -20,7 +20,8 @@ import binascii
 import datetime
 from typing import Any, Type
 
-from google.cloud.spanner_v1.proto import type_pb2
+from google.cloud import spanner
+from google.cloud import spanner_v1
 from spanner_orm import error
 
 
@@ -34,7 +35,7 @@ class FieldType(abc.ABC):
 
   @staticmethod
   @abc.abstractmethod
-  def grpc_type() -> type_pb2.Type:
+  def grpc_type() -> spanner_v1.Type:
     raise NotImplementedError
 
   @staticmethod
@@ -88,8 +89,8 @@ class Boolean(FieldType):
     return 'BOOL'
 
   @staticmethod
-  def grpc_type() -> type_pb2.Type:
-    return type_pb2.Type(code=type_pb2.BOOL)
+  def grpc_type() -> spanner_v1.Type:
+    return spanner.param_types.BOOL
 
   @staticmethod
   def validate_type(value: Any) -> None:
@@ -105,8 +106,8 @@ class Integer(FieldType):
     return 'INT64'
 
   @staticmethod
-  def grpc_type() -> type_pb2.Type:
-    return type_pb2.Type(code=type_pb2.INT64)
+  def grpc_type() -> spanner_v1.Type:
+    return spanner.param_types.INT64
 
   @staticmethod
   def validate_type(value: Any) -> None:
@@ -122,8 +123,8 @@ class Float(FieldType):
     return 'FLOAT64'
 
   @staticmethod
-  def grpc_type() -> type_pb2.Type:
-    return type_pb2.Type(code=type_pb2.FLOAT64)
+  def grpc_type() -> spanner_v1.Type:
+    return spanner.param_types.FLOAT64
 
   @staticmethod
   def validate_type(value: Any) -> None:
@@ -139,8 +140,8 @@ class String(FieldType):
     return 'STRING(MAX)'
 
   @staticmethod
-  def grpc_type() -> type_pb2.Type:
-    return type_pb2.Type(code=type_pb2.STRING)
+  def grpc_type() -> spanner_v1.Type:
+    return spanner.param_types.STRING
 
   @staticmethod
   def validate_type(value) -> None:
@@ -156,8 +157,8 @@ class StringArray(FieldType):
     return 'ARRAY<STRING(MAX)>'
 
   @staticmethod
-  def grpc_type() -> type_pb2.Type:
-    return type_pb2.Type(code=type_pb2.ARRAY)
+  def grpc_type() -> spanner_v1.Type:
+    return spanner.param_types.Array(spanner.param_types.STRING)
 
   @staticmethod
   def validate_type(value: Any) -> None:
@@ -176,8 +177,8 @@ class Timestamp(FieldType):
     return 'TIMESTAMP'
 
   @staticmethod
-  def grpc_type() -> type_pb2.Type:
-    return type_pb2.Type(code=type_pb2.TIMESTAMP)
+  def grpc_type() -> spanner_v1.Type:
+    return spanner.param_types.TIMESTAMP
 
   @staticmethod
   def validate_type(value: Any) -> None:
@@ -193,8 +194,8 @@ class BytesBase64(FieldType):
     return 'BYTES(MAX)'
 
   @staticmethod
-  def grpc_type() -> type_pb2.Type:
-    return type_pb2.Type(code=type_pb2.BYTES)
+  def grpc_type() -> spanner_v1.Type:
+    return spanner.param_types.BYTES
 
   @staticmethod
   def validate_type(value) -> None:

--- a/spanner_orm/table_apis.py
+++ b/spanner_orm/table_apis.py
@@ -19,8 +19,8 @@ from typing import Any, Dict, Iterable, List, Sequence
 
 # TODO(https://github.com/google/pytype/issues/1081): Remove pytype disable.
 from google.cloud import spanner  # pytype: disable=import-error
+from google.cloud import spanner_v1
 from google.cloud.spanner_v1 import transaction as spanner_transaction
-from google.cloud.spanner_v1.proto import type_pb2
 
 _logger = logging.getLogger(__name__)
 
@@ -50,9 +50,10 @@ def find(transaction: spanner_transaction.Transaction, table_name: str,
   return list(stream_results)
 
 
-def sql_query(transaction: spanner_transaction.Transaction, query: str,
-              parameters: Dict[str, Any],
-              parameter_types: Dict[str, type_pb2.Type]) -> List[Sequence[Any]]:
+def sql_query(
+    transaction: spanner_transaction.Transaction, query: str,
+    parameters: Dict[str, Any],
+    parameter_types: Dict[str, spanner_v1.Type]) -> List[Sequence[Any]]:
   """Executes a given SQL query against the Spanner database.
 
   This isn't technically read-only, but it's necessary to implement the read-

--- a/spanner_orm/testlib/spanner_emulator/testlib.py
+++ b/spanner_orm/testlib/spanner_emulator/testlib.py
@@ -55,9 +55,9 @@ def _get_instance(spanner_client: client.Client) -> instance.Instance:
   Args:
     spanner_client: An initialized spanner client.
   """
-  existing_instances = list(spanner_client.list_instances())
-  if existing_instances:
-    return existing_instances[0]
+  existing_instances_pb = list(spanner_client.list_instances())
+  if existing_instances_pb:
+    return instance.Instance.from_pb(existing_instances_pb[0], spanner_client)
 
   # The emulator has one default config.
   config = list(spanner_client.list_instance_configs())[0]

--- a/spanner_orm/tests/condition_test.py
+++ b/spanner_orm/tests/condition_test.py
@@ -22,7 +22,8 @@ import unittest
 
 from absl.testing import parameterized
 from google.api_core import datetime_helpers
-from google.cloud.spanner_v1.proto import type_pb2
+from google.cloud import spanner
+from google.cloud import spanner_v1
 
 import spanner_orm
 from spanner_orm import condition
@@ -45,30 +46,30 @@ class ConditionTest(
         ))
 
   @parameterized.parameters(
-      (True, type_pb2.Type(code=type_pb2.BOOL)),
-      (0, type_pb2.Type(code=type_pb2.INT64)),
-      (0.0, type_pb2.Type(code=type_pb2.FLOAT64)),
+      (True, spanner_v1.param_types.BOOL),
+      (0, spanner_v1.param_types.INT64),
+      (0.0, spanner_v1.param_types.FLOAT64),
       (
           datetime_helpers.DatetimeWithNanoseconds(2021, 1, 5),
-          type_pb2.Type(code=type_pb2.TIMESTAMP),
+          spanner_v1.param_types.TIMESTAMP,
       ),
-      (datetime.datetime(2021, 1, 5), type_pb2.Type(code=type_pb2.TIMESTAMP)),
-      (datetime.date(2021, 1, 5), type_pb2.Type(code=type_pb2.DATE)),
-      (b'\x01', type_pb2.Type(code=type_pb2.BYTES)),
-      ('foo', type_pb2.Type(code=type_pb2.STRING)),
-      (decimal.Decimal('1.23'), type_pb2.Type(code=type_pb2.NUMERIC)),
+      (datetime.datetime(2021, 1, 5), spanner_v1.param_types.TIMESTAMP),
+      (datetime.date(2021, 1, 5), spanner_v1.param_types.DATE),
+      (b'\x01', spanner_v1.param_types.BYTES),
+      ('foo', spanner_v1.param_types.STRING),
+      (decimal.Decimal('1.23'), spanner_v1.param_types.NUMERIC),
       (
           (0, 1),
-          type_pb2.Type(
-              code=type_pb2.ARRAY,
-              array_element_type=type_pb2.Type(code=type_pb2.INT64),
+          spanner_v1.Type(
+              code=spanner_v1.TypeCode.ARRAY,
+              array_element_type=spanner_v1.param_types.INT64,
           ),
       ),
       (
           ['a', None, 'b'],
-          type_pb2.Type(
-              code=type_pb2.ARRAY,
-              array_element_type=type_pb2.Type(code=type_pb2.STRING),
+          spanner_v1.Type(
+              code=spanner_v1.TypeCode.ARRAY,
+              array_element_type=spanner_v1.param_types.STRING,
           ),
       ),
   )
@@ -160,8 +161,8 @@ class ConditionTest(
               key_param0='some-key',
           ),
           dict(
-              true_param0=type_pb2.Type(code=type_pb2.BOOL),
-              key_param0=type_pb2.Type(code=type_pb2.STRING),
+              true_param0=spanner_v1.param_types.BOOL,
+              key_param0=spanner_v1.param_types.STRING,
           ),
           ('SmallTestModel.key = '
            'IF(@true_param0, @key_param0, SmallTestModel.value_1)'),
@@ -248,7 +249,7 @@ class ConditionTest(
           condition.OrCondition(
               [condition.equal_to(models.SmallTestModel.key, 'a')]),
           dict(key0='a'),
-          dict(key0=type_pb2.Type(code=type_pb2.STRING)),
+          dict(key0=spanner_v1.param_types.STRING),
           '((SmallTestModel.key = @key0))',
           'a',
       ),
@@ -271,10 +272,10 @@ class ConditionTest(
               value_13='b',
           ),
           dict(
-              key0=type_pb2.Type(code=type_pb2.STRING),
-              value_11=type_pb2.Type(code=type_pb2.STRING),
-              key2=type_pb2.Type(code=type_pb2.STRING),
-              value_13=type_pb2.Type(code=type_pb2.STRING),
+              key0=spanner_v1.param_types.STRING,
+              value_11=spanner_v1.param_types.STRING,
+              key2=spanner_v1.param_types.STRING,
+              value_13=spanner_v1.param_types.STRING,
           ),
           ('('
            '(SmallTestModel.key = @key0 AND SmallTestModel.value_1 = @value_11)'

--- a/spanner_orm/tests/query_test.py
+++ b/spanner_orm/tests/query_test.py
@@ -24,7 +24,7 @@ from spanner_orm import field
 from spanner_orm import query
 from spanner_orm.tests import models
 
-from google.cloud.spanner_v1.proto import type_pb2
+from google.cloud import spanner_v1
 
 
 def now():
@@ -178,8 +178,8 @@ class QueryTest(parameterized.TestCase):
       column_key = '{}0'.format(column)
       expected_sql = ' WHERE table.{} {} UNNEST(@{})'.format(
           column, current_condition.operator, column_key)
-      list_type = type_pb2.Type(
-          code=type_pb2.ARRAY, array_element_type=grpc_type)
+      list_type = spanner_v1.Type(
+          code=spanner_v1.TypeCode.ARRAY, array_element_type=grpc_type)
       self.assertEndsWith(select_query.sql(), expected_sql)
       self.assertEqual(select_query.parameters(), {column_key: values})
       self.assertEqual(select_query.types(), {column_key: list_type})


### PR DESCRIPTION
CC @dgorelik 

google-cloud-spanner v2 has some fairly significant breaking changes caused by moving some files around. It has a nice [guide for upgrading from 1.x to 2.x](https://github.com/googleapis/python-spanner/blob/main/UPGRADING.md) which I followed to make this PR.

One thing that is ever so slightly bothering me is how we've been running this in prod with google-cloud-spanner 3.x. That really shouldn't work and I suspect we've somehow partially imported 1.x and 3.x I'm just not sure how. I'll feel a lot better about the whole situation when spanner-orm is designed to work with modern google-cloud-spanner instead.