### PR TITLE
Add __repr__() to Model.

### DIFF
--- a/spanner_orm/model.py
+++ b/spanner_orm/model.py
@@ -196,6 +196,9 @@ class Model(metaclass=ModelMetaclass):
       return NotImplemented
     return self.values == other.values
 
+  def __repr__(self) -> str:
+    return f'{self.__class__.__qualname__}({self.values!r})'
+
   @classmethod
   def spanner_api(cls) -> api.SpannerApi:
     if not cls.table:

--- a/spanner_orm/tests/model_test.py
+++ b/spanner_orm/tests/model_test.py
@@ -333,6 +333,11 @@ class ModelTest(
   def test_model_are_different(self, test_model1, test_model2):
     self.assertNotEqual(test_model1, test_model2)
 
+  def test_repr(self):
+    self.assertEqual(
+        "SmallTestModel({'key': 'a', 'value_1': 'b', 'value_2': None})",
+        repr(models.SmallTestModel(dict(key='a', value_1='b', value_2=None))))
+
   def test_id(self):
     primary_key = {'string': 'foo', 'int_': 5, 'float_': 2.3, 'bytes_': b'A1A1'}
     all_data = primary_key.copy()


### PR DESCRIPTION
This makes it a lot easier to see what's wrong when a unit test
assertion about models fails.