### PR TITLE
Pin pytype to a version before a bug we're seeing a lot of

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,9 @@ jobs:
         yapf --diff --recursive --parallel .
     - name: Check types
       run: |
-        pip install pytype
+        # TODO(https://github.com/google/pytype/issues/1081): Remove the version
+        # pin.
+        pip install pytype==2021.11.29
         pytype --jobs=auto --keep-going spanner_orm
     - name: Test
       env:

--- a/spanner_orm/api.py
+++ b/spanner_orm/api.py
@@ -21,8 +21,7 @@ import warnings
 from google.api_core import client_options as api_client_options
 from google.api_core import exceptions
 from google.auth import credentials as auth_credentials
-# TODO(https://github.com/google/pytype/issues/1081): Remove pytype disable.
-from google.cloud import spanner  # pytype: disable=import-error
+from google.cloud import spanner
 from google.cloud.spanner_v1 import database as spanner_database
 from google.cloud.spanner_v1 import pool as spanner_pool
 from spanner_orm import error

--- a/spanner_orm/model.py
+++ b/spanner_orm/model.py
@@ -31,8 +31,7 @@ from spanner_orm import relationship
 from spanner_orm import table_apis
 
 from google.api_core import exceptions
-# TODO(https://github.com/google/pytype/issues/1081): Remove pytype disable.
-from google.cloud import spanner  # pytype: disable=import-error
+from google.cloud import spanner
 from google.cloud.spanner_v1 import transaction as spanner_transaction
 
 T = TypeVar('T')

--- a/spanner_orm/table_apis.py
+++ b/spanner_orm/table_apis.py
@@ -17,8 +17,7 @@
 import logging
 from typing import Any, Dict, Iterable, List, Sequence
 
-# TODO(https://github.com/google/pytype/issues/1081): Remove pytype disable.
-from google.cloud import spanner  # pytype: disable=import-error
+from google.cloud import spanner
 from google.cloud.spanner_v1 import transaction as spanner_transaction
 from google.cloud.spanner_v1.proto import type_pb2
 

--- a/spanner_orm/tests/api_test.py
+++ b/spanner_orm/tests/api_test.py
@@ -19,8 +19,7 @@ import warnings
 
 from absl.testing import parameterized
 from google.api_core import exceptions
-# TODO(https://github.com/google/pytype/issues/1081): Remove pytype disable.
-from google.cloud import spanner  # pytype: disable=import-error
+from google.cloud import spanner
 
 from spanner_orm import api
 from spanner_orm import error

--- a/spanner_orm/tests/model_test.py
+++ b/spanner_orm/tests/model_test.py
@@ -22,8 +22,7 @@ from unittest import mock
 
 from absl.testing import parameterized
 from google.api_core import exceptions
-# TODO(https://github.com/google/pytype/issues/1081): Remove pytype disable.
-from google.cloud import spanner  # pytype: disable=import-error
+from google.cloud import spanner
 from spanner_orm import error
 from spanner_orm import field
 from spanner_orm.testlib.spanner_emulator import testlib as spanner_emulator_testlib


### PR DESCRIPTION
https://github.com/google/pytype/issues/1081 is making
https://github.com/google/python-spanner-orm/pull/171 more difficult, so
we decided to pin pytype rather than add more disable comments.