### PR TITLE
Unpin pytype

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,9 +53,7 @@ jobs:
         yapf --diff --recursive --parallel .
     - name: Check types
       run: |
-        # TODO(https://github.com/google/pytype/issues/1081): Remove the version
-        # pin.
-        pip install pytype==2021.11.29
+        pip install pytype
         pytype --jobs=auto --keep-going spanner_orm
     - name: Test
       env:

--- a/spanner_orm/admin/migration_manager.py
+++ b/spanner_orm/admin/migration_manager.py
@@ -74,7 +74,8 @@ class MigrationManager:
     path = os.path.join(self.basedir, filename)
     module = importlib.util.module_from_spec(
         importlib.util.spec_from_file_location(module_name, path))
-    importlib.machinery.SourceFileLoader(module_name, path).exec_module(module)
+    # TODO(https://github.com/google/pytype/issues/1289): Re-enable pyi-error.
+    importlib.machinery.SourceFileLoader(module_name, path).exec_module(module)  # pytype: disable=pyi-error
     try:
       result = migration.Migration(module.migration_id,
                                    module.prev_migration_id,

--- a/spanner_orm/api.py
+++ b/spanner_orm/api.py
@@ -17,10 +17,11 @@ import abc
 from typing import Any, Callable, Dict, Iterable, Optional, TypeVar, Union
 import warnings
 
+# TODO(https://github.com/google/pytype/issues/1081): Re-enable import-error.
 from google.api_core import client_options as api_client_options
 from google.api_core import exceptions
 from google.auth import credentials as auth_credentials
-from google.cloud import spanner
+from google.cloud import spanner  # pytype: disable=import-error
 from google.cloud.spanner_v1 import database as spanner_database
 from google.cloud.spanner_v1 import pool as spanner_pool
 from spanner_orm import error

--- a/spanner_orm/condition.py
+++ b/spanner_orm/condition.py
@@ -28,9 +28,10 @@ from spanner_orm import foreign_key_relationship
 from spanner_orm import index
 from spanner_orm import relationship
 
+# TODO(https://github.com/google/pytype/issues/1081): Re-enable import-error.
 from google.api_core import datetime_helpers
-from google.cloud import spanner
-from google.cloud import spanner_v1
+from google.cloud import spanner  # pytype: disable=import-error
+from google.cloud import spanner_v1  # pytype: disable=import-error
 import immutabledict
 
 T = TypeVar('T')

--- a/spanner_orm/field.py
+++ b/spanner_orm/field.py
@@ -19,8 +19,9 @@ import binascii
 import datetime
 from typing import Any, Optional, Type
 
-from google.cloud import spanner
-from google.cloud import spanner_v1
+# TODO(https://github.com/google/pytype/issues/1081): Re-enable import-error.
+from google.cloud import spanner  # pytype: disable=import-error
+from google.cloud import spanner_v1  # pytype: disable=import-error
 from spanner_orm import error
 
 

--- a/spanner_orm/model.py
+++ b/spanner_orm/model.py
@@ -29,8 +29,9 @@ from spanner_orm import registry
 from spanner_orm import relationship
 from spanner_orm import table_apis
 
+# TODO(https://github.com/google/pytype/issues/1081): Re-enable import-error.
 from google.api_core import exceptions
-from google.cloud import spanner
+from google.cloud import spanner  # pytype: disable=import-error
 from google.cloud.spanner_v1 import transaction as spanner_transaction
 
 T = TypeVar('T')

--- a/spanner_orm/table_apis.py
+++ b/spanner_orm/table_apis.py
@@ -16,7 +16,8 @@
 import logging
 from typing import Any, Dict, Iterable, List, Sequence
 
-from google.cloud import spanner
+# TODO(https://github.com/google/pytype/issues/1081): Re-enable import-error.
+from google.cloud import spanner  # pytype: disable=import-error
 from google.cloud import spanner_v1
 from google.cloud.spanner_v1 import transaction as spanner_transaction
 
@@ -49,9 +50,12 @@ def find(transaction: spanner_transaction.Transaction, table_name: str,
 
 
 def sql_query(
-    transaction: spanner_transaction.Transaction, query: str,
+    transaction: spanner_transaction.Transaction,
+    query: str,
     parameters: Dict[str, Any],
-    parameter_types: Dict[str, spanner_v1.Type]) -> List[Sequence[Any]]:
+    # TODO(https://github.com/google/pytype/issues/1287): Re-enable module-attr.
+    parameter_types: Dict[str, spanner_v1.Type],  # pytype: disable=module-attr
+) -> List[Sequence[Any]]:
   """Executes a given SQL query against the Spanner database.
 
   This isn't technically read-only, but it's necessary to implement the read-

--- a/spanner_orm/tests/api_test.py
+++ b/spanner_orm/tests/api_test.py
@@ -16,9 +16,10 @@ import unittest
 from unittest import mock
 import warnings
 
+# TODO(https://github.com/google/pytype/issues/1081): Re-enable import-error.
 from absl.testing import parameterized
 from google.api_core import exceptions
-from google.cloud import spanner
+from google.cloud import spanner  # pytype: disable=import-error
 
 from spanner_orm import api
 from spanner_orm import error

--- a/spanner_orm/tests/condition_test.py
+++ b/spanner_orm/tests/condition_test.py
@@ -19,9 +19,10 @@ import logging
 import os
 import unittest
 
+# TODO(https://github.com/google/pytype/issues/1081): Re-enable import-error.
 from absl.testing import parameterized
 from google.api_core import datetime_helpers
-from google.cloud import spanner
+from google.cloud import spanner  # pytype: disable=import-error
 from google.cloud import spanner_v1
 
 import spanner_orm
@@ -45,6 +46,9 @@ class ConditionTest(
         ))
 
   @parameterized.parameters(
+      # TODO(https://github.com/google/pytype/issues/1287): Re-enable
+      # module-attr.
+      # pytype: disable=module-attr
       (True, spanner_v1.param_types.BOOL),
       (0, spanner_v1.param_types.INT64),
       (0.0, spanner_v1.param_types.FLOAT64),
@@ -71,6 +75,7 @@ class ConditionTest(
               array_element_type=spanner_v1.param_types.STRING,
           ),
       ),
+      # pytype: enable=module-attr
   )
   def test_param_from_value(self, value, expected_type):
     param = condition.Param.from_value(value)
@@ -132,6 +137,9 @@ class ConditionTest(
     self.assertCountEqual((test_model,), models.SmallTestModel.where(tautology))
 
   @parameterized.named_parameters(
+      # TODO(https://github.com/google/pytype/issues/1287): Re-enable
+      # module-attr.
+      # pytype: disable=module-attr
       (
           'minimal',
           condition.ArbitraryCondition(
@@ -167,6 +175,7 @@ class ConditionTest(
            'IF(@true_param0, @key_param0, SmallTestModel.value_1)'),
           ('some-key',),
       ),
+      # pytype: enable=module-attr
   )
   def test_arbitrary_condition(
       self,
@@ -227,6 +236,9 @@ class ConditionTest(
       models.SmallTestModel.where(condition_)
 
   @parameterized.named_parameters(
+      # TODO(https://github.com/google/pytype/issues/1287): Re-enable
+      # module-attr.
+      # pytype: disable=module-attr
       (
           'empty_or',
           condition.OrCondition(),
@@ -283,6 +295,7 @@ class ConditionTest(
            ')'),
           'ab',
       ),
+      # pytype: enable=module-attr
   )
   def test_or_condition(
       self,

--- a/spanner_orm/tests/model_test.py
+++ b/spanner_orm/tests/model_test.py
@@ -19,9 +19,10 @@ from typing import List
 import unittest
 from unittest import mock
 
+# TODO(https://github.com/google/pytype/issues/1081): Re-enable import-error.
 from absl.testing import parameterized
 from google.api_core import exceptions
-from google.cloud import spanner
+from google.cloud import spanner  # pytype: disable=import-error
 from spanner_orm import error
 from spanner_orm import field
 from spanner_orm.testlib.spanner_emulator import testlib as spanner_emulator_testlib

--- a/spanner_orm/tests/query_test.py
+++ b/spanner_orm/tests/query_test.py
@@ -177,8 +177,10 @@ class QueryTest(parameterized.TestCase):
       column_key = '{}0'.format(column)
       expected_sql = ' WHERE table.{} {} UNNEST(@{})'.format(
           column, current_condition.operator, column_key)
-      list_type = spanner_v1.Type(
-          code=spanner_v1.TypeCode.ARRAY, array_element_type=grpc_type)
+      # TODO(https://github.com/google/pytype/issues/1287): Re-enable module-attr.
+      list_type = spanner_v1.Type(  # pytype: disable=module-attr
+          code=spanner_v1.TypeCode.ARRAY,  # pytype: disable=module-attr
+          array_element_type=grpc_type)
       self.assertEndsWith(select_query.sql(), expected_sql)
       self.assertEqual(select_query.parameters(), {column_key: values})
       self.assertEqual(select_query.types(), {column_key: list_type})


### PR DESCRIPTION
The import-error bug is annoying, but 1) it would be nice to get updated pytype changes again and 2) this is holding us back from supporting python 3.10.