### PR TITLE
Use instances of FieldType instead of classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ class TestModel(spanner_orm.Model):
   # is the type of field. The primary key is constructed by the fields labeled
   # with primary_key=True in the order they appear in the class.
   # The name of the column is the same as the name of the class attribute
-  id = spanner_orm.Field(spanner_orm.String, primary_key=True)
-  value = spanner_orm.Field(spanner_orm.Integer, nullable=True)
-  number = spanner_orm.Field(spanner_orm.Float, nullable=True)
+  id = spanner_orm.Field(spanner_orm.String(), primary_key=True)
+  value = spanner_orm.Field(spanner_orm.Integer(), nullable=True)
+  number = spanner_orm.Field(spanner_orm.Float(), nullable=True)
 
   # Secondary indexes are specified in a similar manner to fields:
   value_index = spanner_orm.Index(['value'])

--- a/spanner_orm/admin/column.py
+++ b/spanner_orm/admin/column.py
@@ -36,10 +36,5 @@ class ColumnSchema(schema.InformationSchema):
   def nullable(self) -> bool:
     return self.is_nullable == 'YES'
 
-  def field_type(self) -> Type[field.FieldType]:
-    for field_type in field.ALL_TYPES:
-      if self.spanner_type == field_type.ddl():
-        return field_type
-
-    raise error.SpannerError('No corresponding Type for {}'.format(
-        self.spanner_type))
+  def field_type(self) -> field.FieldType:
+    return field.field_type_from_ddl(self.spanner_type)

--- a/spanner_orm/admin/update.py
+++ b/spanner_orm/admin/update.py
@@ -220,7 +220,7 @@ class AlterColumn(SchemaUpdate):
 
     old_field = model_.fields[self._column]
     # Validate that the only alteration is to change column nullability
-    if self._field.field_type() != old_field.field_type():
+    if self._field.field_type().ddl() != old_field.field_type().ddl():
       raise error.SpannerError('Column {} is changing type'.format(
           self._column))
     if self._field.nullable() == old_field.nullable():

--- a/spanner_orm/condition.py
+++ b/spanner_orm/condition.py
@@ -355,7 +355,7 @@ class ColumnsEqualCondition(Condition):
           self.destination_column, self.destination_model_class.table))
     dest = self.destination_model_class.fields[self.destination_column]
 
-    if (origin.field_type() != dest.field_type() or
+    if (not origin.field_type().comparable_with(dest.field_type()) or
         origin.nullable() != dest.nullable()):
       raise error.ValidationError('Types of {} and {} do not match'.format(
           origin.name, dest.name))

--- a/spanner_orm/tests/admin_test.py
+++ b/spanner_orm/tests/admin_test.py
@@ -108,8 +108,8 @@ class AdminTest(unittest.TestCase):
     self.assertEqual(meta.table, model.table)
     self.assertEqual(meta.columns, model.columns)
     for row in model.columns:
-      self.assertEqual(meta.fields[row].field_type(),
-                       model.fields[row].field_type())
+      self.assertEqual(meta.fields[row].field_type().ddl(),
+                       model.fields[row].field_type().ddl())
       self.assertEqual(meta.fields[row].nullable(),
                        model.fields[row].nullable())
     self.assertEqual(meta.primary_keys, model.primary_keys)

--- a/spanner_orm/tests/field_test.py
+++ b/spanner_orm/tests/field_test.py
@@ -1,0 +1,67 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for field."""
+
+import warnings
+
+from spanner_orm import error
+from spanner_orm import field
+from absl.testing import absltest
+from absl.testing import parameterized
+
+
+class FieldTest(parameterized.TestCase):
+
+  @parameterized.parameters(
+      (field.Boolean(), field.Boolean(), True),
+      (field.Boolean(), field.String(), False),
+  )
+  def test_field_type_comparable_with(
+      self,
+      field_type_1: field.FieldType,
+      field_type_2: field.FieldType,
+      expected_comparable: bool,
+  ):
+    self.assertEqual(
+        field_type_1.comparable_with(field_type_2), expected_comparable)
+    self.assertEqual(
+        field_type_2.comparable_with(field_type_1), expected_comparable)
+
+  def test_field_field_type_is_class(self):
+    with warnings.catch_warnings(record=True) as actual_warnings:
+      self.assertIsInstance(
+          field.Field(field.String).field_type(), field.String)
+    self.assertLen(actual_warnings, 1)
+    self.assertIn('instance of FieldType', str(actual_warnings[0].message))
+    self.assertIs(actual_warnings[0].category, DeprecationWarning)
+
+  @parameterized.parameters(
+      'BOOL',
+      'INT64',
+      'FLOAT64',
+      'STRING(MAX)',
+      'ARRAY<STRING(MAX)>',
+      'TIMESTAMP',
+      'BYTES(MAX)',
+  )
+  def test_ddl_to_field_type_to_ddl(self, ddl: str):
+    self.assertEqual(field.field_type_from_ddl(ddl).ddl(), ddl)
+
+  def test_field_type_from_ddl_invalid(self):
+    with self.assertRaisesRegex(error.SpannerError, 'DDL type'):
+      field.field_type_from_ddl('UNICORN(MAX)')
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/spanner_orm/tests/model_test.py
+++ b/spanner_orm/tests/model_test.py
@@ -374,7 +374,8 @@ class ModelTest(
 
   def test_field_exists_on_model_class(self):
     self.assertIsInstance(models.SmallTestModel.key, field.Field)
-    self.assertEqual(models.SmallTestModel.key.field_type(), field.String)
+    self.assertEqual(models.SmallTestModel.key.field_type().ddl(),
+                     'STRING(MAX)')
     self.assertFalse(models.SmallTestModel.key.nullable())
     self.assertEqual(models.SmallTestModel.key.name, 'key')
 

--- a/spanner_orm/tests/query_test.py
+++ b/spanner_orm/tests/query_test.py
@@ -42,7 +42,7 @@ class QueryTest(parameterized.TestCase):
     expected_sql = 'SELECT .* FROM table WHERE table.int_ = @int_0'
     self.assertRegex(sql, expected_sql)
     self.assertEqual(parameters, {'int_0': 3})
-    self.assertEqual(types, {'int_0': field.Integer.grpc_type()})
+    self.assertEqual(types, {'int_0': field.Integer().grpc_type()})
 
   @mock.patch('spanner_orm.table_apis.sql_query')
   def test_count(self, sql_query):
@@ -56,7 +56,7 @@ class QueryTest(parameterized.TestCase):
         column, column_key)
     self.assertRegex(sql, expected_sql)
     self.assertEqual({column_key: value}, parameters)
-    self.assertEqual(types, {column_key: field.Integer.grpc_type()})
+    self.assertEqual(types, {column_key: field.Integer().grpc_type()})
 
   def test_count_allows_force_index(self):
     force_index = condition.force_index('test_index')
@@ -81,7 +81,7 @@ class QueryTest(parameterized.TestCase):
 
     self.assertEndsWith(select_query.sql(), ' LIMIT @{}'.format(key))
     self.assertEqual(select_query.parameters(), {key: value})
-    self.assertEqual(select_query.types(), {key: field.Integer.grpc_type()})
+    self.assertEqual(select_query.types(), {key: field.Integer().grpc_type()})
 
     select_query = self.select()
     self.assertNotRegex(select_query.sql(), 'LIMIT')
@@ -97,10 +97,11 @@ class QueryTest(parameterized.TestCase):
         limit_key: limit,
         offset_key: offset
     })
-    self.assertEqual(select_query.types(), {
-        limit_key: field.Integer.grpc_type(),
-        offset_key: field.Integer.grpc_type()
-    })
+    self.assertEqual(
+        select_query.types(), {
+            limit_key: field.Integer().grpc_type(),
+            offset_key: field.Integer().grpc_type()
+        })
 
   def test_query_order_by(self):
     order = ('int_', condition.OrderType.DESC)
@@ -124,9 +125,9 @@ class QueryTest(parameterized.TestCase):
     select_query = self.select()
     self.assertNotRegex(select_query.sql(), 'ORDER BY')
 
-  @parameterized.parameters(('int_', 5, field.Integer.grpc_type()),
-                            ('string', 'foo', field.String.grpc_type()),
-                            ('timestamp', now(), field.Timestamp.grpc_type()))
+  @parameterized.parameters(('int_', 5, field.Integer().grpc_type()),
+                            ('string', 'foo', field.String().grpc_type()),
+                            ('timestamp', now(), field.Timestamp().grpc_type()))
   def test_query_where_comparison(self, column, value, grpc_type):
     condition_generators = [
         condition.greater_than, condition.not_less_than, condition.less_than,
@@ -144,9 +145,9 @@ class QueryTest(parameterized.TestCase):
       self.assertEqual(select_query.types(), {column_key: grpc_type})
 
   @parameterized.parameters(
-      (models.UnittestModel.int_, 5, field.Integer.grpc_type()),
-      (models.UnittestModel.string, 'foo', field.String.grpc_type()),
-      (models.UnittestModel.timestamp, now(), field.Timestamp.grpc_type()))
+      (models.UnittestModel.int_, 5, field.Integer().grpc_type()),
+      (models.UnittestModel.string, 'foo', field.String().grpc_type()),
+      (models.UnittestModel.timestamp, now(), field.Timestamp().grpc_type()))
   def test_query_where_comparison_with_object(self, column, value, grpc_type):
     condition_generators = [
         condition.greater_than, condition.not_less_than, condition.less_than,
@@ -164,10 +165,10 @@ class QueryTest(parameterized.TestCase):
       self.assertEqual(select_query.types(), {column_key: grpc_type})
 
   @parameterized.parameters(
-      ('int_', [1, 2, 3], field.Integer.grpc_type()),
-      ('int_', (4, 5, 6), field.Integer.grpc_type()),
-      ('string', ['a', 'b', 'c'], field.String.grpc_type()),
-      ('timestamp', [now()], field.Timestamp.grpc_type()))
+      ('int_', [1, 2, 3], field.Integer().grpc_type()),
+      ('int_', (4, 5, 6), field.Integer().grpc_type()),
+      ('string', ['a', 'b', 'c'], field.String().grpc_type()),
+      ('timestamp', [now()], field.Timestamp().grpc_type()))
   def test_query_where_list_comparison(self, column, values, grpc_type):
     condition_generators = [condition.in_list, condition.not_in_list]
     for condition_generator in condition_generators:
@@ -461,8 +462,8 @@ class QueryTest(parameterized.TestCase):
     self.assertEndsWith(select_query.sql(), expected_sql)
     self.assertEqual(select_query.parameters(), {'int_0': 1, 'int_1': 2})
     self.assertEqual(select_query.types(), {
-        'int_0': field.Integer.grpc_type(),
-        'int_1': field.Integer.grpc_type()
+        'int_0': field.Integer().grpc_type(),
+        'int_1': field.Integer().grpc_type()
     })
 
 


### PR DESCRIPTION
Aside from
<https://google.github.io/styleguide/pyguide.html#217-function-and-method-decorators>, this makes it possible to have types with parameters. E.g., this makes it possible to add code for something like Array(String(length=20)) for the type ARRAY<STRING(20)>. That way we don't need to define a new FooArray class for each type of array, and we can add support for lengths other than MAX more easily.

This could break any users that use FieldType for anything other than passing to Field, but hopefully the vast majority of uses just pass it to Field.