### PR TITLE
Trigger tests for PRs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 on:
+  pull_request: {}
   push: {}
   schedule:
   - cron: '50 13 * * *'


### PR DESCRIPTION
Most of our PRs are from branches in this repo, so the push trigger covered those. But I don't think the push trigger covers pushes to branches in other repos that have open PRs in this repo.