### PR TITLE
Spanner orm upgrade

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,7 @@ jobs:
         pip install \
           absl-py \
           google-api-core \
-          'google-cloud-spanner >= 2, <4' \
+          'google-cloud-spanner >= 3, <4' \
           immutabledict \
           portpicker \
           pytest

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup
 
 setup(
     name='spanner-orm',
-    version='0.2.0',
+    version='0.3.0',
     description='Basic ORM for Spanner',
     maintainer='Python Spanner ORM developers',
     maintainer_email='python-spanner-orm@google.com',
@@ -25,7 +25,7 @@ setup(
     include_package_data=True,
     python_requires='~=3.8',
     install_requires=[
-        'google-cloud-spanner >= 2, <4',
+        'google-cloud-spanner >= 3, <4',
         'immutabledict',
     ],
     tests_require=['absl-py', 'google-api-core', 'portpicker'],

--- a/spanner_orm/__init__.py
+++ b/spanner_orm/__init__.py
@@ -113,8 +113,3 @@ ExecutePartitionedDml = update_module.ExecutePartitionedDml
 model_creation_ddl = update_module.model_creation_ddl
 
 MigrationExecutor = migration_executor.MigrationExecutor
-
-try:
-  __import__('pkg_resources').declare_namespace('spanner_orm')
-except ImportError:
-  __path__ = __import__('pkgutil').extend_path(__path__, 'spanner_orm')

--- a/spanner_orm/testlib/spanner_emulator/emulator.py
+++ b/spanner_orm/testlib/spanner_emulator/emulator.py
@@ -15,6 +15,7 @@
 
 import os
 import subprocess
+import time
 from typing import Mapping, Optional
 
 import portpicker
@@ -65,6 +66,7 @@ class Emulator:
     self._host_port = None
 
     self._start()
+    time.sleep(1)
     self._wait_for_ready()
 
   def get_client(

--- a/spanner_orm/tests/migrations_emulator_test.py
+++ b/spanner_orm/tests/migrations_emulator_test.py
@@ -124,7 +124,7 @@ class SpecificMigrationsEmulatorTest(
             class _Parent(spanner_orm.Model):
               __table__ = 'Parent'
               parent_key = spanner_orm.Field(
-                  spanner_orm.String, primary_key=True)
+                  spanner_orm.String(), primary_key=True)
 
             def upgrade():
               return spanner_orm.CreateTable(_Parent)
@@ -133,15 +133,15 @@ class SpecificMigrationsEmulatorTest(
             class _Parent(spanner_orm.Model):
               __table__ = 'Parent'
               parent_key = spanner_orm.Field(
-                  spanner_orm.String, primary_key=True)
+                  spanner_orm.String(), primary_key=True)
 
             class _Child(spanner_orm.Model):
               __table__ = 'Child'
               __interleaved__ = _Parent
               parent_key = spanner_orm.Field(
-                  spanner_orm.String, primary_key=True)
+                  spanner_orm.String(), primary_key=True)
               child_key = spanner_orm.Field(
-                  spanner_orm.String, primary_key=True)
+                  spanner_orm.String(), primary_key=True)
 
             def upgrade():
               return spanner_orm.CreateTable(_Child)
@@ -170,8 +170,8 @@ class SpecificMigrationsEmulatorTest(
                   class _TableToDrop(spanner_orm.Model):
                     __table__ = 'TableToDrop'
                     key = spanner_orm.Field(
-                        spanner_orm.String, primary_key=True)
-                    value = spanner_orm.Field(spanner_orm.String)
+                        spanner_orm.String(), primary_key=True)
+                    value = spanner_orm.Field(spanner_orm.String())
 
                   def upgrade():
                     return spanner_orm.CreateTable(_TableToDrop)
@@ -194,7 +194,7 @@ class SpecificMigrationsEmulatorTest(
                   class _TableToDrop(spanner_orm.Model):
                     __table__ = 'TableToDrop'
                     parent_key = spanner_orm.Field(
-                        spanner_orm.String, primary_key=True)
+                        spanner_orm.String(), primary_key=True)
 
                   def upgrade():
                     return spanner_orm.CreateTable(_TableToDrop)
@@ -203,15 +203,15 @@ class SpecificMigrationsEmulatorTest(
                   class _TableToDrop(spanner_orm.Model):
                     __table__ = 'TableToDrop'
                     parent_key = spanner_orm.Field(
-                        spanner_orm.String, primary_key=True)
+                        spanner_orm.String(), primary_key=True)
 
                   class _Child(spanner_orm.Model):
                     __table__ = 'Child'
                     __interleaved__ = _TableToDrop
                     parent_key = spanner_orm.Field(
-                        spanner_orm.String, primary_key=True)
+                        spanner_orm.String(), primary_key=True)
                     child_key = spanner_orm.Field(
-                        spanner_orm.String, primary_key=True)
+                        spanner_orm.String(), primary_key=True)
 
                   def upgrade():
                     return spanner_orm.CreateTable(_Child)

--- a/spanner_orm/tests/migrations_for_emulator_test/create_custom_length_field_f959b767457d.py
+++ b/spanner_orm/tests/migrations_for_emulator_test/create_custom_length_field_f959b767457d.py
@@ -16,7 +16,7 @@ class OriginalTeeTable(spanner_orm.model.Model):
   """
 
   __table__ = 'Tee'
-  id = spanner_orm.Field(spanner_orm.String, primary_key=True)
+  id = spanner_orm.Field(spanner_orm.String(), primary_key=True)
   custom_string_length = spanner_orm.Field(spanner_orm.String(20))
   custom_array_string_length = spanner_orm.Field(
       spanner_orm.Array(spanner_orm.String(4)))

--- a/spanner_orm/tests/migrations_for_emulator_test/create_foreign_key_test_model.py
+++ b/spanner_orm/tests/migrations_for_emulator_test/create_foreign_key_test_model.py
@@ -29,10 +29,10 @@ class OriginalForeignKeyTestModelTable(spanner_orm.model.Model):
   """ORM Model with the original schema for the ForeignKeyTestModel table."""
 
   __table__ = 'ForeignKeyTestModel'
-  referencing_key_1 = field.Field(field.String, primary_key=True)
-  referencing_key_2 = field.Field(field.String, primary_key=True)
-  referencing_key_3 = field.Field(field.Integer, primary_key=True)
-  self_referencing_key = field.Field(field.String, nullable=True)
+  referencing_key_1 = field.Field(field.String(), primary_key=True)
+  referencing_key_2 = field.Field(field.String(), primary_key=True)
+  referencing_key_3 = field.Field(field.Integer(), primary_key=True)
+  self_referencing_key = field.Field(field.String(), nullable=True)
   foreign_key_1 = foreign_key_relationship.ForeignKeyRelationship(
       'SmallTestModel', {'referencing_key_1': 'key'})
   foreign_key_2 = foreign_key_relationship.ForeignKeyRelationship(

--- a/spanner_orm/tests/migrations_for_emulator_test/create_null_filtered_index_model_760ec5fae5da.py
+++ b/spanner_orm/tests/migrations_for_emulator_test/create_null_filtered_index_model_760ec5fae5da.py
@@ -25,9 +25,9 @@ prev_migration_id = 'f735d6b706d4'
 
 class _NullFilteredIndexModel(spanner_orm.Model):
   __table__ = 'NullFilteredIndexModel'
-  key = spanner_orm.Field(spanner_orm.String, primary_key=True)
-  value_1 = spanner_orm.Field(spanner_orm.String, nullable=True)
-  value_2 = spanner_orm.Field(spanner_orm.Integer)
+  key = spanner_orm.Field(spanner_orm.String(), primary_key=True)
+  value_1 = spanner_orm.Field(spanner_orm.String(), nullable=True)
+  value_2 = spanner_orm.Field(spanner_orm.Integer())
 
 
 def upgrade() -> spanner_orm.MigrationUpdate:

--- a/spanner_orm/tests/migrations_for_emulator_test/create_small_test_model.py
+++ b/spanner_orm/tests/migrations_for_emulator_test/create_small_test_model.py
@@ -28,9 +28,9 @@ class OriginalSmallTestModelTable(spanner_orm.model.Model):
   """ORM Model with the original schema for the SmallTestModel table."""
 
   __table__ = 'SmallTestModel'
-  key = field.Field(field.String, primary_key=True)
-  value_1 = field.Field(field.String)
-  value_2 = field.Field(field.String, nullable=True)
+  key = field.Field(field.String(), primary_key=True)
+  value_1 = field.Field(field.String())
+  value_2 = field.Field(field.String(), nullable=True)
 
 
 def upgrade() -> spanner_orm.CreateTable:

--- a/spanner_orm/tests/migrations_for_emulator_test/create_unittest_model.py
+++ b/spanner_orm/tests/migrations_for_emulator_test/create_unittest_model.py
@@ -28,18 +28,18 @@ class OriginalUnittestModelTable(spanner_orm.model.Model):
   """ORM Model with the original schema for the UnittestModel table."""
 
   __table__ = 'table'
-  int_ = field.Field(field.Integer, primary_key=True)
-  int_2 = field.Field(field.Integer, nullable=True)
-  float_ = field.Field(field.Float, primary_key=True)
-  float_2 = field.Field(field.Float, nullable=True)
-  string = field.Field(field.String, primary_key=True)
-  string_2 = field.Field(field.String, nullable=True)
+  int_ = field.Field(field.Integer(), primary_key=True)
+  int_2 = field.Field(field.Integer(), nullable=True)
+  float_ = field.Field(field.Float(), primary_key=True)
+  float_2 = field.Field(field.Float(), nullable=True)
+  string = field.Field(field.String(), primary_key=True)
+  string_2 = field.Field(field.String(), nullable=True)
   string_3 = field.Field(field.String(20), nullable=True)
   bytes_ = field.Field(field.BytesBase64, primary_key=True)
   bytes_2 = field.Field(field.BytesBase64, nullable=True)
   bytes_3 = field.Field(field.BytesBase64(20), nullable=True)
   timestamp = field.Field(field.Timestamp)
-  string_array = field.Field(field.StringArray, nullable=True)
+  string_array = field.Field(field.Array(field.String()), nullable=True)
   string_array_2 = field.Field(field.Array(field.String(20)), nullable=True)
 
 


### PR DESCRIPTION
b/432303478
Updates the library to be compatible with Google Cloud Spanner 3.x and resolves several deprecation warnings.

CC @jagankumarm 